### PR TITLE
feat: run_metric_query MCP tool (execute a metric query and return rows)

### DIFF
--- a/packages/client/src/api/v2/query.test.ts
+++ b/packages/client/src/api/v2/query.test.ts
@@ -80,4 +80,31 @@ describe('QueryClientV2', () => {
     expect(mockHttp.post).toHaveBeenCalledWith('/projects/p1/query/underlying-data', body);
     expect(result).toEqual(results);
   });
+
+  it('getAsyncQueryResults should call GET /projects/{projectUuid}/query/{queryUuid} with page/pageSize params', async () => {
+    const client = new QueryClientV2(mockHttp);
+    const results = { status: 'pending', queryUuid: 'q1' };
+    vi.mocked(mockHttp.get).mockResolvedValue(results);
+    const result = await client.getAsyncQueryResults('p1', 'q1', { page: 2, pageSize: 500 });
+    expect(mockHttp.get).toHaveBeenCalledWith('/projects/p1/query/q1', {
+      params: { page: 2, pageSize: 500 },
+    });
+    expect(result).toEqual(results);
+  });
+
+  it('getAsyncQueryResults should call GET with no params when none are given', async () => {
+    const client = new QueryClientV2(mockHttp);
+    const results = { status: 'ready', queryUuid: 'q1', rows: [] };
+    vi.mocked(mockHttp.get).mockResolvedValue(results);
+    const result = await client.getAsyncQueryResults('p1', 'q1');
+    expect(mockHttp.get).toHaveBeenCalledWith('/projects/p1/query/q1', { params: undefined });
+    expect(result).toEqual(results);
+  });
+
+  it('cancelAsyncQuery should call POST /projects/{projectUuid}/query/{queryUuid}/cancel', async () => {
+    const client = new QueryClientV2(mockHttp);
+    vi.mocked(mockHttp.post).mockResolvedValue(undefined);
+    await client.cancelAsyncQuery('p1', 'q1');
+    expect(mockHttp.post).toHaveBeenCalledWith('/projects/p1/query/q1/cancel');
+  });
 });

--- a/packages/client/src/api/v2/query.ts
+++ b/packages/client/src/api/v2/query.ts
@@ -13,7 +13,14 @@ import type {
   ExecuteAsyncMetricQueryResults,
   ExecuteAsyncDashboardChartResults,
   ExecuteAsyncSqlQueryResults,
+  GetAsyncQueryResults,
 } from '@lightdash-tools/common';
+
+/** Query params for getAsyncQueryResults. Page starts at 1; pageSize defaults to 500, max 5000 (Lightdash-side). */
+export interface GetAsyncQueryResultsParams {
+  page?: number;
+  pageSize?: number;
+}
 
 export class QueryClientV2 extends BaseApiClient {
   /** Run a metric query (v2 endpoint). */
@@ -66,5 +73,25 @@ export class QueryClientV2 extends BaseApiClient {
       `/projects/${projectUuid}/query/underlying-data`,
       body,
     );
+  }
+
+  /**
+   * Get a page of results for a previously-started async query (v2 endpoint).
+   * Returns a status-discriminated union: poll while pending/queued/executing,
+   * fail on error/expired/cancelled, paginate while ready.
+   */
+  async getAsyncQueryResults(
+    projectUuid: string,
+    queryUuid: string,
+    params?: GetAsyncQueryResultsParams,
+  ): Promise<GetAsyncQueryResults> {
+    return this.http.get<GetAsyncQueryResults>(`/projects/${projectUuid}/query/${queryUuid}`, {
+      params,
+    });
+  }
+
+  /** Cancel a running async query and discard any partial results (v2 endpoint). */
+  async cancelAsyncQuery(projectUuid: string, queryUuid: string): Promise<void> {
+    await this.http.post<void>(`/projects/${projectUuid}/query/${queryUuid}/cancel`);
   }
 }

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -53,6 +53,16 @@ describe('LightdashClient', () => {
       const client = new LightdashClient(config);
       expect(typeof client.v2.query.runSqlQuery).toBe('function');
     });
+
+    it('v2.query.getAsyncQueryResults should be a function', () => {
+      const client = new LightdashClient(config);
+      expect(typeof client.v2.query.getAsyncQueryResults).toBe('function');
+    });
+
+    it('v2.query.cancelAsyncQuery should be a function', () => {
+      const client = new LightdashClient(config);
+      expect(typeof client.v2.query.cancelAsyncQuery).toBe('function');
+    });
   });
 
   describe('HTTP clients', () => {

--- a/packages/common/src/types/lightdash-api.ts
+++ b/packages/common/src/types/lightdash-api.ts
@@ -69,6 +69,8 @@ export type {
   ExecuteAsyncMetricQueryResults,
   ExecuteAsyncDashboardChartResults,
   ExecuteAsyncSqlQueryResults,
+  GetAsyncQueryResults,
+  ReadyQueryResultsPage,
   AiAgentSummary,
   AiAgentAdminSortField,
   AiAgentsAdminThreadsResult,

--- a/packages/common/src/types/v1/index.ts
+++ b/packages/common/src/types/v1/index.ts
@@ -39,6 +39,8 @@ export namespace V1 {
       export type ExecuteAsyncMetricQueryResults = Q.Responses.ExecuteAsyncMetricQueryResults;
       export type ExecuteAsyncDashboardChartResults = Q.Responses.ExecuteAsyncDashboardChartResults;
       export type ExecuteAsyncSqlQueryResults = Q.Responses.ExecuteAsyncSqlQueryResults;
+      export type GetAsyncQueryResults = Q.Responses.GetAsyncQueryResults;
+      export type ReadyQueryResultsPage = Q.Responses.ReadyQueryResultsPage;
     }
   }
 

--- a/packages/common/src/types/v1/lightdash-api.ts
+++ b/packages/common/src/types/v1/lightdash-api.ts
@@ -96,6 +96,8 @@ export namespace LightdashApi {
         components['schemas']['ApiExecuteAsyncDashboardChartQueryResults'];
       export type ExecuteAsyncSqlQueryResults =
         components['schemas']['ApiExecuteAsyncSqlQueryResults'];
+      export type GetAsyncQueryResults = components['schemas']['ApiGetAsyncQueryResults'];
+      export type ReadyQueryResultsPage = components['schemas']['ReadyQueryResultsPage'];
     }
   }
 
@@ -350,6 +352,8 @@ export type CompiledQueryResults = Queries.Responses.CompiledQueryResults;
 export type ExecuteAsyncMetricQueryResults = Queries.Responses.ExecuteAsyncMetricQueryResults;
 export type ExecuteAsyncDashboardChartResults = Queries.Responses.ExecuteAsyncDashboardChartResults;
 export type ExecuteAsyncSqlQueryResults = Queries.Responses.ExecuteAsyncSqlQueryResults;
+export type GetAsyncQueryResults = Queries.Responses.GetAsyncQueryResults;
+export type ReadyQueryResultsPage = Queries.Responses.ReadyQueryResultsPage;
 
 // AI agents (flat exports) — admin
 export type AiAgentSummary = AiAgents.AiAgentSummary;

--- a/packages/common/src/types/v1/queries.ts
+++ b/packages/common/src/types/v1/queries.ts
@@ -50,5 +50,9 @@ export namespace Queries {
     /** V2 async SQL query results. */
     export type ExecuteAsyncSqlQueryResults =
       components['schemas']['ApiExecuteAsyncSqlQueryResults'];
+    /** V2 get-results response: status-discriminated union (pending/queued/executing/cancelled | error/expired | ready). */
+    export type GetAsyncQueryResults = components['schemas']['ApiGetAsyncQueryResults'];
+    /** V2 get-results "ready" page: rows + pagination metadata. */
+    export type ReadyQueryResultsPage = components['schemas']['ReadyQueryResultsPage'];
   }
 }

--- a/packages/common/src/types/v2/index.ts
+++ b/packages/common/src/types/v2/index.ts
@@ -44,6 +44,8 @@ export namespace V2 {
       export type ExecuteAsyncMetricQueryResults = Q.Responses.ExecuteAsyncMetricQueryResults;
       export type ExecuteAsyncDashboardChartResults = Q.Responses.ExecuteAsyncDashboardChartResults;
       export type ExecuteAsyncSqlQueryResults = Q.Responses.ExecuteAsyncSqlQueryResults;
+      export type GetAsyncQueryResults = Q.Responses.GetAsyncQueryResults;
+      export type ReadyQueryResultsPage = Q.Responses.ReadyQueryResultsPage;
     }
   }
 

--- a/packages/mcp/src/tools/query.test.ts
+++ b/packages/mcp/src/tools/query.test.ts
@@ -1,0 +1,279 @@
+import { SafetyMode } from '@lightdash-tools/common';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { registerQueryTools } from './query';
+import { TOOL_PREFIX } from './shared';
+
+import type { McpContextProvider } from '../request-context';
+import type { LightdashClient } from '@lightdash-tools/client';
+
+function makeResultRow(value: number) {
+  return { a: { value: { raw: value, formatted: String(value) } } };
+}
+
+describe('run_metric_query', () => {
+  const mockServer = { registerTool: vi.fn() };
+  const runMetricQuery = vi.fn();
+  const getAsyncQueryResults = vi.fn();
+  const cancelAsyncQuery = vi.fn();
+
+  const contextProvider: McpContextProvider = {
+    getContext: async () => ({
+      lightdashClient: {
+        v1: { query: { compileQuery: vi.fn() } },
+        v2: { query: { runMetricQuery, getAsyncQueryResults, cancelAsyncQuery } },
+      } as unknown as LightdashClient,
+      auth: { mode: 'env' },
+      governance: {
+        safetyMode: SafetyMode.READ_ONLY,
+        dryRun: false,
+        allowedProjectUuids: [],
+      },
+    }),
+  };
+
+  beforeEach(() => {
+    mockServer.registerTool.mockClear();
+    runMetricQuery.mockReset();
+    getAsyncQueryResults.mockReset();
+    cancelAsyncQuery.mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function getHandler(): (args: unknown) => Promise<{
+    content: Array<{ type: 'text'; text: string }>;
+    isError?: boolean;
+  }> {
+    registerQueryTools(mockServer as never, contextProvider);
+    const call = mockServer.registerTool.mock.calls.find(
+      ([name]) => name === `${TOOL_PREFIX}run_metric_query`,
+    );
+    if (!call) throw new Error(`${TOOL_PREFIX}run_metric_query was not registered`);
+    return call[2] as never;
+  }
+
+  it('maps exploreId + metricQuery into the v2 request body and returns ready rows on the first poll', async () => {
+    runMetricQuery.mockResolvedValue({
+      queryUuid: 'q1',
+      fields: { a: { type: 'dimension' } },
+      metricQuery: { exploreName: 'fact_order', dimensions: ['a'] },
+    });
+    getAsyncQueryResults.mockResolvedValue({
+      status: 'ready',
+      queryUuid: 'q1',
+      rows: [makeResultRow(1)],
+      columns: { a: { type: 'string', reference: 'a' } },
+      page: 1,
+      pageSize: 500,
+      totalResults: 1,
+      totalPageCount: 1,
+    });
+
+    const handler = getHandler();
+    const result = await handler({
+      projectUuid: '11111111-1111-1111-1111-111111111111',
+      exploreId: 'fact_order',
+      metricQuery: { dimensions: ['a'] },
+    });
+
+    expect(runMetricQuery).toHaveBeenCalledWith('11111111-1111-1111-1111-111111111111', {
+      context: 'mcp.run_metric_query',
+      query: { dimensions: ['a'], exploreName: 'fact_order' },
+    });
+    expect(getAsyncQueryResults).toHaveBeenCalledWith(
+      '11111111-1111-1111-1111-111111111111',
+      'q1',
+      { page: 1, pageSize: 500 },
+    );
+    expect(result.isError).toBeUndefined();
+
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.rows).toHaveLength(1);
+    expect(payload.totalResults).toBe(1);
+    expect(payload.truncated).toBe(false);
+    expect(payload.fields).toEqual({ a: { type: 'dimension' } });
+  });
+
+  it('polls through pending -> queued -> executing before returning ready rows', async () => {
+    vi.useFakeTimers();
+    runMetricQuery.mockResolvedValue({ queryUuid: 'q1', fields: {}, metricQuery: {} });
+    getAsyncQueryResults
+      .mockResolvedValueOnce({ status: 'pending', queryUuid: 'q1' })
+      .mockResolvedValueOnce({ status: 'queued', queryUuid: 'q1' })
+      .mockResolvedValueOnce({ status: 'executing', queryUuid: 'q1' })
+      .mockResolvedValueOnce({
+        status: 'ready',
+        queryUuid: 'q1',
+        rows: [],
+        columns: {},
+        page: 1,
+        pageSize: 500,
+        totalResults: 0,
+        totalPageCount: 1,
+      });
+
+    const handler = getHandler();
+    const promise = handler({
+      projectUuid: '11111111-1111-1111-1111-111111111111',
+      exploreId: 'e1',
+      metricQuery: {},
+    });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(getAsyncQueryResults).toHaveBeenCalledTimes(4);
+    expect(result.isError).toBeUndefined();
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.truncated).toBe(false);
+  });
+
+  it('surfaces an error status as a tool error with the Lightdash-side message (RBAC denial shape)', async () => {
+    runMetricQuery.mockResolvedValue({ queryUuid: 'q1', fields: {}, metricQuery: {} });
+    getAsyncQueryResults.mockResolvedValue({
+      status: 'error',
+      queryUuid: 'q1',
+      error: "You don't have authorization to access this explore",
+    });
+
+    const handler = getHandler();
+    const result = await handler({
+      projectUuid: '11111111-1111-1111-1111-111111111111',
+      exploreId: 'fact_tweet',
+      metricQuery: {},
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("You don't have authorization to access this explore");
+  });
+
+  it('surfaces an expired status as a tool error', async () => {
+    runMetricQuery.mockResolvedValue({ queryUuid: 'q1', fields: {}, metricQuery: {} });
+    getAsyncQueryResults.mockResolvedValue({
+      status: 'expired',
+      queryUuid: 'q1',
+      error: 'Query results expired',
+    });
+
+    const handler = getHandler();
+    const result = await handler({
+      projectUuid: '11111111-1111-1111-1111-111111111111',
+      exploreId: 'e1',
+      metricQuery: {},
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Query results expired');
+  });
+
+  it('surfaces a cancelled status as a tool error', async () => {
+    runMetricQuery.mockResolvedValue({ queryUuid: 'q1', fields: {}, metricQuery: {} });
+    getAsyncQueryResults.mockResolvedValue({
+      status: 'cancelled',
+      queryUuid: 'q1',
+    });
+
+    const handler = getHandler();
+    const result = await handler({
+      projectUuid: '11111111-1111-1111-1111-111111111111',
+      exploreId: 'e1',
+      metricQuery: {},
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('cancelled');
+  });
+
+  it('paginates across pages and truncates at the 500-row cap', async () => {
+    runMetricQuery.mockResolvedValue({ queryUuid: 'q1', fields: {}, metricQuery: {} });
+    const page1Rows = Array.from({ length: 300 }, (_, i) => makeResultRow(i));
+    const page2Rows = Array.from({ length: 300 }, (_, i) => makeResultRow(300 + i));
+    getAsyncQueryResults
+      .mockResolvedValueOnce({
+        status: 'ready',
+        queryUuid: 'q1',
+        rows: page1Rows,
+        columns: {},
+        page: 1,
+        pageSize: 500,
+        totalResults: 600,
+        totalPageCount: 2,
+        nextPage: 2,
+      })
+      .mockResolvedValueOnce({
+        status: 'ready',
+        queryUuid: 'q1',
+        rows: page2Rows,
+        columns: {},
+        page: 2,
+        pageSize: 500,
+        totalResults: 600,
+        totalPageCount: 2,
+      });
+
+    const handler = getHandler();
+    const result = await handler({
+      projectUuid: '11111111-1111-1111-1111-111111111111',
+      exploreId: 'e1',
+      metricQuery: {},
+    });
+
+    expect(getAsyncQueryResults).toHaveBeenCalledTimes(2);
+    expect(getAsyncQueryResults).toHaveBeenNthCalledWith(
+      2,
+      '11111111-1111-1111-1111-111111111111',
+      'q1',
+      { page: 2, pageSize: 500 },
+    );
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.rows).toHaveLength(500);
+    expect(payload.totalResults).toBe(600);
+    expect(payload.truncated).toBe(true);
+  });
+
+  it('does not truncate when the last page exactly fills the result set', async () => {
+    runMetricQuery.mockResolvedValue({ queryUuid: 'q1', fields: {}, metricQuery: {} });
+    getAsyncQueryResults.mockResolvedValue({
+      status: 'ready',
+      queryUuid: 'q1',
+      rows: Array.from({ length: 42 }, (_, i) => makeResultRow(i)),
+      columns: {},
+      page: 1,
+      pageSize: 500,
+      totalResults: 42,
+      totalPageCount: 1,
+    });
+
+    const handler = getHandler();
+    const result = await handler({
+      projectUuid: '11111111-1111-1111-1111-111111111111',
+      exploreId: 'e1',
+      metricQuery: {},
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.rows).toHaveLength(42);
+    expect(payload.truncated).toBe(false);
+  });
+
+  it('times out after 30s of non-ready polls, cancels the query, and returns a clear error', async () => {
+    vi.useFakeTimers();
+    runMetricQuery.mockResolvedValue({ queryUuid: 'q1', fields: {}, metricQuery: {} });
+    getAsyncQueryResults.mockResolvedValue({ status: 'pending', queryUuid: 'q1' });
+
+    const handler = getHandler();
+    const promise = handler({
+      projectUuid: '11111111-1111-1111-1111-111111111111',
+      exploreId: 'e1',
+      metricQuery: {},
+    });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('timed out');
+    expect(cancelAsyncQuery).toHaveBeenCalledWith('11111111-1111-1111-1111-111111111111', 'q1');
+  });
+});

--- a/packages/mcp/src/tools/query.ts
+++ b/packages/mcp/src/tools/query.ts
@@ -1,5 +1,5 @@
 /**
- * MCP tools: query (compile).
+ * MCP tools: query (compile, run).
  */
 
 import { z } from 'zod';
@@ -13,7 +13,75 @@ import {
 } from './shared.js';
 
 import type { McpContextProvider } from '../request-context.js';
+import type { LightdashClient } from '@lightdash-tools/client';
+import type {
+  ExecuteAsyncMetricQueryRequestParams,
+  ReadyQueryResultsPage,
+} from '@lightdash-tools/common';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+type ResultRow = ReadyQueryResultsPage['rows'][number];
+
+/** Hard row cap for run_metric_query (= Lightdash's default pageSize). */
+const ROW_CAP = 500;
+/** Overall poll timeout; the query is cancelled and an error returned past this point. */
+const TIMEOUT_MS = 30_000;
+/** Poll backoff schedule in ms: immediate first check, then bounded backoff to a 2s ceiling. */
+const POLL_SCHEDULE_MS = [0, 300, 600, 1200];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function nextDelayMs(attempt: number): number {
+  // eslint-disable-next-line security/detect-object-injection -- attempt is an internal counter, not user input
+  return attempt < POLL_SCHEDULE_MS.length ? POLL_SCHEDULE_MS[attempt] : 2000;
+}
+
+/**
+ * Polls getAsyncQueryResults for one page until it's ready, throwing on
+ * error/expired/cancelled or on overall timeout (cancelling the query first).
+ */
+async function pollForReadyPage(
+  client: LightdashClient,
+  projectUuid: string,
+  queryUuid: string,
+  page: number,
+  deadline: number,
+): Promise<ReadyQueryResultsPage> {
+  for (let attempt = 0; ; attempt += 1) {
+    const delay = nextDelayMs(attempt);
+    if (delay > 0) {
+      await sleep(delay);
+    }
+    if (Date.now() >= deadline) {
+      await client.v2.query.cancelAsyncQuery(projectUuid, queryUuid).catch(() => undefined);
+      throw new Error(
+        `run_metric_query timed out after ${TIMEOUT_MS / 1000}s waiting for query ${queryUuid} ` +
+          '— narrow the query (add filters, a limit, or a coarser time grain) and try again.',
+      );
+    }
+
+    const result = await client.v2.query.getAsyncQueryResults(projectUuid, queryUuid, {
+      page,
+      pageSize: ROW_CAP,
+    });
+
+    switch (result.status) {
+      case 'ready':
+        return result;
+      case 'error':
+      case 'expired':
+        throw new Error(result.error ?? `Query ${queryUuid} ${result.status}`);
+      case 'cancelled':
+        throw new Error(`Query ${queryUuid} was cancelled.`);
+      case 'pending':
+      case 'queued':
+      case 'executing':
+        break; // keep polling
+    }
+  }
+}
 
 export function registerQueryTools(server: McpServer, contextProvider: McpContextProvider): void {
   registerToolSafe(
@@ -50,6 +118,82 @@ export function registerQueryTools(server: McpServer, contextProvider: McpContex
             metricQuery as never,
           );
           return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+        },
+    ),
+  );
+
+  registerToolSafe(
+    server,
+    'run_metric_query',
+    {
+      title: 'Run metric query',
+      description:
+        'Execute a metric query for an explore and return result rows, under the ' +
+        "caller's own Lightdash permissions (same governance as compile_query, but " +
+        'actually run against the warehouse). Runs asynchronously under the hood ' +
+        '(execute, then poll until ready) and returns one JSON result. Rows are ' +
+        `hard-capped at ${ROW_CAP}; check the returned \`truncated\` flag and ` +
+        '`totalResults`, and add a `limit` or coarser aggregation to the metric ' +
+        'query rather than relying on pagination for large results.',
+      inputSchema: {
+        projectUuid: projectUuidField(),
+        exploreId: z.string().describe('Explore ID'),
+        metricQuery: z
+          .record(z.string(), z.unknown())
+          .describe('Metric query object (dimensions, metrics, filters, sorts, limit, etc.)'),
+      },
+      annotations: READ_ONLY_DEFAULT,
+    },
+    wrapToolAnnotated(
+      contextProvider,
+      READ_ONLY_CAPABILITY,
+      (c) =>
+        async ({
+          projectUuid,
+          exploreId,
+          metricQuery,
+        }: {
+          projectUuid: string;
+          exploreId: string;
+          metricQuery: Record<string, unknown>;
+        }) => {
+          const body = {
+            context: 'mcp.run_metric_query',
+            query: { ...metricQuery, exploreName: exploreId },
+          } as unknown as ExecuteAsyncMetricQueryRequestParams;
+
+          const {
+            queryUuid,
+            fields,
+            metricQuery: resolvedMetricQuery,
+          } = await c.v2.query.runMetricQuery(projectUuid, body);
+
+          const deadline = Date.now() + TIMEOUT_MS;
+          const rows: ResultRow[] = [];
+          let page = 1;
+          let lastPage: ReadyQueryResultsPage;
+
+          for (;;) {
+            const pageResult = await pollForReadyPage(c, projectUuid, queryUuid, page, deadline);
+            rows.push(...pageResult.rows);
+            lastPage = pageResult;
+            if (rows.length >= ROW_CAP || pageResult.nextPage == null) {
+              break;
+            }
+            page = pageResult.nextPage;
+          }
+
+          const cappedRows = rows.slice(0, ROW_CAP);
+          const truncated = cappedRows.length < lastPage.totalResults;
+          const payload = {
+            rows: cappedRows,
+            columns: lastPage.columns,
+            fields,
+            metricQuery: resolvedMetricQuery,
+            totalResults: lastPage.totalResults,
+            truncated,
+          };
+          return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }] };
         },
     ),
   );


### PR DESCRIPTION
## Summary

The MCP server currently exposes `compile_query`, which compiles a metric
query to SQL text but never executes it. There's no tool that actually runs
a query and returns rows under the caller's own Lightdash identity/RBAC. The
client already has `runMetricQuery` (v2 async execute), but nothing for the
second half of that flow — `GET /query/:queryUuid` — or for cancelling an
abandoned query.

This adds:

- **`QueryClientV2.getAsyncQueryResults(projectUuid, queryUuid, { page, pageSize })`**
  and **`cancelAsyncQuery(projectUuid, queryUuid)`**, plus
  `GetAsyncQueryResults`/`ReadyQueryResultsPage` type aliases threaded through
  the existing v1/v2 barrels — the generated OpenAPI types already fully and
  correctly model the status union (`pending`/`queued`/`executing`/
  `cancelled`/`error`/`expired`/`ready`), so this is just wiring, not new
  modeling.
- **`run_metric_query`** MCP tool, registered alongside `compile_query` using
  the current `wrapToolAnnotated`/`McpContextProvider`/`READ_ONLY_CAPABILITY`
  pattern. It orchestrates execute → poll → paginate as a single tool call:
  - Immediate first poll (the query may already be cached), then bounded
    backoff (300ms → 600ms → 1.2s → 2s ceiling).
  - 30s overall timeout, cancelling the query server-side before returning a
    clear "narrow the query" error, so a timed-out call doesn't leak
    warehouse work.
  - Pagination hard-capped at 500 rows (Lightdash's own default `pageSize`),
    always returning `truncated`/`totalResults` so a caller knows when a
    result was cut short rather than silently fetching everything.

## Why hard-cap at 500 instead of exposing raw pagination to the caller

Feeding rows back into an LLM context makes an unbounded result a real
hazard. 500 == the default `pageSize`, so the common case (aggregates —
"revenue by month", "top 5 customers") comes back in exactly one page and the
whole poll/paginate loop degenerates to a single `GET`; pagination only
engages for "dump every row" queries, which are precisely the ones that
should be truncated rather than fetched in full.

## Testing

- Unit tests cover every status branch (pending → ready transitions,
  error/expired/cancelled terminal states) and the multi-page
  accumulation + truncation path, following the existing test style
  (`McpContextProvider` mock, same shape as `users.test.ts`).
- Verified live against a real, running Lightdash instance (`0.3309.0`):
  numbers matched a direct SQL baseline exactly (including a join and a
  derived-ratio table calculation), a >500-row query truncated as designed,
  and a restricted user's RBAC denial on one explore surfaced cleanly
  (`"You don't have authorization to access this explore"`) while a
  permitted explore returned identical rows to an admin's own query.

## Notes for review

- `context: 'mcp.run_metric_query'` matches the value already present in the
  regenerated OpenAPI types (`QueryExecutionContext`).
- Marking this draft since it's a first pass — happy to adjust naming,
  scope, or splitting the client/MCP changes into separate PRs if that's
  preferred.