### PR TITLE
chore(release): bump monorepo to 0.8.0

### DIFF
--- a/.changes/0.8.0.
+++ b/.changes/0.8.0.
@@ -1,0 +1,8 @@
+## [0.8.0] - 2026-08-02
+### Features
+* Add content-reader MCP persona for project-scoped saved-content reads and bounded semantic chart execution (ADR-0012).
+* Add content-governance MCP persona with elicitation-gated soft-delete for charts and dashboards (ADR-0015).
+* Add elicitation-gated dashboard promote (and read-only promoteDiff) on the content-governance MCP persona.
+* Add pluggable MCP ephemeral store (memory/redis) and preview claim/apply/release state machine (ADR-0016).
+### Bug Fixes
+* Redact MCP emails on direct access and omit project connection secrets by default (ADR-0011).

--- a/.changes/unreleased/feat-20260801-162540.yaml
+++ b/.changes/unreleased/feat-20260801-162540.yaml
@@ -1,3 +1,0 @@
-kind: feat
-body: Add content-reader MCP persona for project-scoped saved-content reads and bounded semantic chart execution (ADR-0012).
-time: 2026-08-01T16:25:40.464461+09:00

--- a/.changes/unreleased/feat-20260802-124933.yaml
+++ b/.changes/unreleased/feat-20260802-124933.yaml
@@ -1,3 +1,0 @@
-kind: feat
-body: Add pluggable MCP ephemeral store (memory/redis) and preview claim/apply/release state machine (ADR-0016).
-time: 2026-08-02T12:49:33.893257+09:00

--- a/.changes/unreleased/feat-20260802-content-governance-dashboard-promote.yaml
+++ b/.changes/unreleased/feat-20260802-content-governance-dashboard-promote.yaml
@@ -1,1 +1,0 @@
-feat: Add elicitation-gated dashboard promote (and read-only promoteDiff) on the content-governance MCP persona.

--- a/.changes/unreleased/feat-20260802-content-governance-soft-delete.yaml
+++ b/.changes/unreleased/feat-20260802-content-governance-soft-delete.yaml
@@ -1,3 +1,0 @@
-kind: feat
-body: Add content-governance MCP persona with elicitation-gated soft-delete for charts and dashboards (ADR-0015).
-time: 2026-08-02T08:00:00+09:00

--- a/.changes/unreleased/fix-20260801-084127.yaml
+++ b/.changes/unreleased/fix-20260801-084127.yaml
@@ -1,3 +1,0 @@
-kind: fix
-body: Redact MCP emails on direct access and omit project connection secrets by default (ADR-0011).
-time: 2026-08-01T08:41:27.475966+09:00

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.8.0] - 2026-08-02
+
+### Features
+
+- Add content-reader MCP persona for project-scoped saved-content reads and bounded semantic chart execution (ADR-0012).
+- Add content-governance MCP persona with elicitation-gated soft-delete for charts and dashboards (ADR-0015).
+- Add elicitation-gated dashboard promote (and read-only promoteDiff) on the content-governance MCP persona.
+- Add pluggable MCP ephemeral store (memory/redis) and preview claim/apply/release state machine (ADR-0016).
+
+### Bug Fixes
+
+- Redact MCP emails on direct access and omit project connection secrets by default (ADR-0011).
+
 ## [0.7.0] - 2026-08-01
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "description": "",
   "keywords": [],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/cli",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "CLI for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,7 +36,7 @@ const program = new Command();
 program
   .name('lightdash-ai')
   .description('CLI for Lightdash AI')
-  .version('0.7.0')
+  .version('0.8.0')
   .option(
     '--safety-mode <mode>',
     'Safety mode (read-only, write-idempotent, write-destructive)',

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/client",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Client library for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/common",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Shared utilities and types for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/mcp",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "MCP server for Lightdash semantic-layer, organization-audit, content-reader, content-developer, and content-governance personas.",
   "keywords": [],
   "repository": {

--- a/packages/mcp/src/bin.ts
+++ b/packages/mcp/src/bin.ts
@@ -31,7 +31,7 @@ program
   .description(
     'MCP server for Lightdash (semantic-layer, organization-audit, content-reader, content-developer, content-governance). Default stdio persona is semantic-layer.',
   )
-  .version('0.7.0');
+  .version('0.8.0');
 
 program
   .command('stdio')


### PR DESCRIPTION
## Summary
- Bump root and workspace packages (`cli`, `client`, `common`, `mcp`) to `0.8.0`
- Sync CLI/MCP `.version()` entrypoints and batch Changie unreleased fragments into `CHANGELOG.md`

## Test plan
- [ ] Confirm all `package.json` versions are `0.8.0`
- [ ] Confirm CLI/MCP `--version` strings match
- [ ] Confirm `CHANGELOG.md` has a complete `0.8.0` section and unreleased fragments are cleared


Made with [Cursor](https://cursor.com)