### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/.changes/0.9.0.
+++ b/.changes/0.9.0.
@@ -1,0 +1,9 @@
+## [0.9.0] - 2026-08-03
+### Features
+* Breaking: MCP/CLI share LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS allowlist (renamed from ALLOWED_PROJECTS); removes PROJECT_UUID default and MCP_AVAILABLE_PROJECT_UUIDS — startup/CLI fail if legacy ALLOWED_PROJECTS or MCP_AVAILABLE still set; promote_dashboard also fails closed when upstream is outside the ceiling
+* Make MCP HTTP stateless: drop Redis ephemeral store and transport sessions; use HMAC-signed preview tokens; keep in-memory OAuth broker only.
+* content-developer prompts/playbooks require Design Spec approval before dashboard writes
+* content-reader export_chart_image returns a single PNG snapshot (MCP ImageContent; SSRF-hardened download; SQL charts blocked)
+* Emit Cloud Logging–parseable MCP/CLI audit JSON on stderr (channel=audit) with clientSessionId and personaId; document Cloud Run sink/retention.
+### Bug Fixes
+* MCP wrapTool maps uncaught Lightdash API failures to structured UPSTREAM and RATE_LIMITED tool errors; HttpClient rejects malformed success envelopes as ContractError

--- a/.changes/unreleased/feat-20260803-102317.yaml
+++ b/.changes/unreleased/feat-20260803-102317.yaml
@@ -1,3 +1,0 @@
-kind: feat
-body: 'Breaking: MCP/CLI share LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS allowlist (renamed from ALLOWED_PROJECTS); removes PROJECT_UUID default and MCP_AVAILABLE_PROJECT_UUIDS — startup/CLI fail if legacy ALLOWED_PROJECTS or MCP_AVAILABLE still set; promote_dashboard also fails closed when upstream is outside the ceiling'
-time: 2026-08-03T10:23:17.50789+09:00

--- a/.changes/unreleased/feat-20260803-121337.yaml
+++ b/.changes/unreleased/feat-20260803-121337.yaml
@@ -1,3 +1,0 @@
-kind: feat
-body: 'Make MCP HTTP stateless: drop Redis ephemeral store and transport sessions; use HMAC-signed preview tokens; keep in-memory OAuth broker only.'
-time: 2026-08-03T12:13:37.124477+09:00

--- a/.changes/unreleased/feat-20260803-160049.yaml
+++ b/.changes/unreleased/feat-20260803-160049.yaml
@@ -1,3 +1,0 @@
-kind: feat
-body: content-developer prompts/playbooks require Design Spec approval before dashboard writes
-time: 2026-08-03T16:00:49.091404+09:00

--- a/.changes/unreleased/feat-20260803-162613.yaml
+++ b/.changes/unreleased/feat-20260803-162613.yaml
@@ -1,3 +1,0 @@
-kind: feat
-body: content-reader export_chart_image returns a single PNG snapshot (MCP ImageContent; SSRF-hardened download; SQL charts blocked)
-time: 2026-08-03T16:26:13.524919+09:00

--- a/.changes/unreleased/feat-20260803-175334.yaml
+++ b/.changes/unreleased/feat-20260803-175334.yaml
@@ -1,3 +1,0 @@
-kind: feat
-body: Emit Cloud Logging–parseable MCP/CLI audit JSON on stderr (channel=audit) with clientSessionId and personaId; document Cloud Run sink/retention.
-time: 2026-08-03T17:53:34.080346+09:00

--- a/.changes/unreleased/fix-20260803-171144.yaml
+++ b/.changes/unreleased/fix-20260803-171144.yaml
@@ -1,3 +1,0 @@
-kind: fix
-body: MCP wrapTool maps uncaught Lightdash API failures to structured UPSTREAM and RATE_LIMITED tool errors; HttpClient rejects malformed success envelopes as ContractError
-time: 2026-08-03T17:11:44.651562+09:00

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.9.0] - 2026-08-03
+
+### Features
+
+- Breaking: MCP/CLI share LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS allowlist (renamed from ALLOWED_PROJECTS); removes PROJECT_UUID default and MCP_AVAILABLE_PROJECT_UUIDS — startup/CLI fail if legacy ALLOWED_PROJECTS or MCP_AVAILABLE still set; promote_dashboard also fails closed when upstream is outside the ceiling
+- Make MCP HTTP stateless: drop Redis ephemeral store and transport sessions; use HMAC-signed preview tokens; keep in-memory OAuth broker only.
+- content-developer prompts/playbooks require Design Spec approval before dashboard writes
+- content-reader export_chart_image returns a single PNG snapshot (MCP ImageContent; SSRF-hardened download; SQL charts blocked)
+- Emit Cloud Logging–parseable MCP/CLI audit JSON on stderr (channel=audit) with clientSessionId and personaId; document Cloud Run sink/retention.
+
+### Bug Fixes
+
+- MCP wrapTool maps uncaught Lightdash API failures to structured UPSTREAM and RATE_LIMITED tool errors; HttpClient rejects malformed success envelopes as ContractError
+
 ## [0.8.0] - 2026-08-02
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -1,30 +1,69 @@
 # @lightdash-tools
 
-TypeScript monorepo: Lightdash API client, CLI, and MCP server.
+TypeScript client, CLI, and persona-scoped MCP servers for [Lightdash](https://www.lightdash.com/).
 
-## Using the tools
+## Choose your tool
 
-All tools are available as npm packages under the `@lightdash-tools` scope.
+All packages are published under the `@lightdash-tools` npm scope.
 
-- **HTTP client** ([packages/client/README.md](packages/client/README.md)) — Type-safe Lightdash API client with rate limiting, retries, and shared types. Install via [`npm install @lightdash-tools/client`](https://www.npmjs.com/package/@lightdash-tools/client). <!-- markdown-link-check-disable-line -->
-- **CLI** ([packages/cli/README.md](packages/cli/README.md)) — Command-line interface for Lightdash. Run directly via [`npx @lightdash-tools/cli`](https://www.npmjs.com/package/@lightdash-tools/cli) or install globally via `npm install -g @lightdash-tools/cli`. <!-- markdown-link-check-disable-line -->
-- **MCP** ([packages/mcp/README.md](packages/mcp/README.md)) — MCP server that exposes Lightdash as tools for AI assistants. Run directly via [`npx @lightdash-tools/mcp`](https://www.npmjs.com/package/@lightdash-tools/mcp). <!-- markdown-link-check-disable-line -->
+- **HTTP client** ([packages/client/README.md](packages/client/README.md)) — Type-safe Lightdash API client with rate limiting, retries, and shared types. [`npm install @lightdash-tools/client`](https://www.npmjs.com/package/@lightdash-tools/client). <!-- markdown-link-check-disable-line -->
+- **CLI** ([packages/cli/README.md](packages/cli/README.md)) — Command-line interface for Lightdash ops. [`npx @lightdash-tools/cli`](https://www.npmjs.com/package/@lightdash-tools/cli) or `npm install -g @lightdash-tools/cli`. <!-- markdown-link-check-disable-line -->
+- **MCP** ([packages/mcp/README.md](packages/mcp/README.md)) — MCP server that exposes Lightdash as tools for AI assistants (six personas). [`npx @lightdash-tools/mcp`](https://www.npmjs.com/package/@lightdash-tools/mcp). <!-- markdown-link-check-disable-line -->
 
-## AI Safety and Agent-Friendly Features
+## Credentials
 
-**CLI** uses a hierarchical safety stack ([ADR-0005](docs/adr/0005-cli-safety-stack.md)): `LIGHTDASH_TOOLS_SAFETY_MODE` / `--safety-mode` (`read-only` default, `write-idempotent`, `write-destructive`), plus optional dry-run, project allowlist, and audit log.
+Set credentials from the parent process (shell, CI, or MCP client `env`). Create a personal access token in Lightdash under **Settings → Personal Access Tokens**.
 
-**MCP** is persona-first ([ADR-0008](docs/adr/0008-mcp-request-scope-and-hardening.md)): capability = persona `toolIds`; HTTP may pin via `X-Lightdash-Project`; process safety-mode / allowlist / dry-run are **not** used on MCP.
+| Variable                                | Used by                | Purpose                                                              |
+| :-------------------------------------- | :--------------------- | :------------------------------------------------------------------- |
+| `LIGHTDASH_URL`                         | Client, CLI, MCP       | Lightdash instance URL (e.g. `https://app.lightdash.cloud`)          |
+| `LIGHTDASH_API_KEY`                     | Client, CLI, MCP stdio | Personal access token (PAT)                                          |
+| `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS` | CLI + MCP              | Optional comma-separated project UUID ceiling (unset = unrestricted) |
 
-**Shared agent-friendly features:**
+Prefer env vars over plaintext `.env` files when agents can read the filesystem. Details: [docs/secrets-and-credentials.md](docs/secrets-and-credentials.md).
 
-- **Agent-safe surface** — Irrecoverable ops stay off MCP/CLI ([ADR-0004](docs/adr/0004-agent-safe-exposure-mcp-cli-vs-client-only.md)).
-- **Input validation** — Known identifier fields only (`projectUuid`, `slug`, …).
-- **Audit log** — Optional `LIGHTDASH_TOOLS_AUDIT_LOG`.
+## MCP quick start (stdio)
 
-For agent-specific guidance, see [docs/agent-context/CONTEXT.md](docs/agent-context/CONTEXT.md). For credentials, use env vars from your shell or CI; see [docs/secrets-and-credentials.md](docs/secrets-and-credentials.md).
+Add a server to `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project). See [Cursor MCP docs](https://cursor.com/docs/mcp).
 
-Developing? See [CONTRIBUTING.md](CONTRIBUTING.md). For agent instructions see [AGENTS.md](AGENTS.md). For architectural decisions, see [docs/adr/](docs/adr/).
+```json
+{
+  "mcpServers": {
+    "lightdash": {
+      "command": "npx",
+      "args": ["-y", "@lightdash-tools/mcp", "content-reader"],
+      "env": {
+        "LIGHTDASH_URL": "https://app.lightdash.cloud",
+        "LIGHTDASH_API_KEY": "your_pat"
+      }
+    }
+  }
+}
+```
+
+Omit the persona argument for `semantic-layer` (default). Other personas and playbooks: [packages/mcp/README.md](packages/mcp/README.md).
+
+## HTTP MCP
+
+For remote Streamable HTTP (POST-only MCP endpoints, no protocol sessions):
+
+```bash
+npx @lightdash-tools/mcp serve-http
+```
+
+Hosted OAuth for Cursor (URL-only client config): [docs/cursor-lightdash-oauth-mcp.md](docs/cursor-lightdash-oauth-mcp.md). Operator setup: [packages/mcp/README.md](packages/mcp/README.md).
+
+## Safety
+
+- **CLI** — hierarchical safety stack: `LIGHTDASH_TOOLS_SAFETY_MODE` / `--safety-mode` (`read-only` default, `write-idempotent`, `write-destructive`), optional dry-run, shared project allowlist, and audit log ([ADR-0005](docs/adr/0005-cli-safety-stack.md)).
+- **MCP** — capability is the persona tool surface; optional HTTP pin via `X-Lightdash-Project`; shared `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS` ceiling. MCP ignores CLI `SAFETY_MODE` / `DRY_RUN` ([ADR-0008](docs/adr/0008-mcp-request-scope-and-hardening.md)).
+- **Agent-safe surface** — irrecoverable ops stay off MCP and CLI; use the client for those ([ADR-0004](docs/adr/0004-agent-safe-exposure-mcp-cli-vs-client-only.md)).
+
+Agent-oriented notes: [docs/agent-context/CONTEXT.md](docs/agent-context/CONTEXT.md).
+
+## Developing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). Agent instructions: [AGENTS.md](AGENTS.md). Release notes: [CHANGELOG.md](CHANGELOG.md). ADRs: [docs/adr/](docs/adr/).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "description": "",
   "keywords": [],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/cli",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "CLI for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,7 +36,7 @@ const program = new Command();
 program
   .name('lightdash-ai')
   .description('CLI for Lightdash AI')
-  .version('0.8.0')
+  .version('0.9.0')
   .option(
     '--safety-mode <mode>',
     'Safety mode (read-only, write-idempotent, write-destructive)',

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/client",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Client library for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/common",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Shared utilities and types for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/mcp",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "MCP server for Lightdash semantic-layer, organization-audit, content-reader, content-developer, content-governance, and ai-agent-ops personas.",
   "keywords": [],
   "repository": {

--- a/packages/mcp/src/bin.ts
+++ b/packages/mcp/src/bin.ts
@@ -33,7 +33,7 @@ program
   .description(
     'MCP server for Lightdash (semantic-layer, organization-audit, content-reader, content-developer, content-governance, ai-agent-ops). Default stdio persona is semantic-layer.',
   )
-  .version('0.8.0');
+  .version('0.9.0');
 
 program
   .command('stdio')


### PR DESCRIPTION
Batch unreleased Changie fragments and sync workspace package and CLI/MCP entrypoint versions.