### PR TITLE
ci(sbom): replace scan-action with download-grype CLI

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -69,16 +69,22 @@ jobs:
           upload-artifact-retention: 14
           upload-release-assets: false
 
-      - name: Scan SBOM for vulnerabilities
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+      - name: Download Grype
+        id: grype
+        uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:
-          sbom: sbom.spdx.json
-          severity-cutoff: high
-          only-fixed: false
-          fail-build: false
-          output-format: json
-          output-file: grype-report.json
           cache-db: true
+
+      - name: Scan SBOM for vulnerabilities
+        shell: bash
+        env:
+          GRYPE_CMD: ${{ steps.grype.outputs.cmd }}
+        run: |
+          set -euo pipefail
+          "${GRYPE_CMD}" \
+            sbom:sbom.spdx.json \
+            -o json \
+            --file grype-report.json
 
       - name: Enforce High and Critical vulnerability gate
         shell: bash


### PR DESCRIPTION
## Summary
- Replace `anchore/scan-action` with `anchore/scan-action/download-grype` + direct Grype CLI (`sbom:` + `-o json --file`).
- Keep Syft SPDX generation and the existing High/Critical `jq` gate unchanged.
- Pin the same commit SHA as before (`v7.4.0`) and retain `cache-db: true`.

## Test plan
- [ ] SBOM workflow runs on this PR
- [ ] Download Grype step succeeds (DB cache optional)
- [ ] `grype-report.json` is produced and uploaded as an artifact
- [ ] High/Critical gate step still runs; fails only when matches exist


Made with [Cursor](https://cursor.com)