### PR TITLE
ci: tighten workflow permissions for zizmor pedantic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -33,6 +34,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/dependency_audit_fix.yml
+++ b/.github/workflows/dependency_audit_fix.yml
@@ -35,16 +35,20 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   audit-fix:
     name: pnpm audit --fix and open PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Commit audit --fix changes and push branch
+      pull-requests: write # Open remediation PR
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -68,6 +72,7 @@ jobs:
         run: pnpm audit --fix update
 
       - name: Create pull request
+        # zizmor: ignore[superfluous-actions] create-pull-request handles commit+push+PR; gh alone needs more plumbing
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,6 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   publish:
@@ -33,14 +32,16 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     permissions:
-      contents: read
-      id-token: write
+      contents: read # Checkout sources for publish
+      id-token: write # npm Trusted Publishing (OIDC)
     defaults:
       run:
         shell: bash
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/trunk_check.yml
+++ b/.github/workflows/trunk_check.yml
@@ -22,7 +22,8 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   trunk_check:
@@ -35,6 +36,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit

--- a/.github/workflows/trunk_upgrade.yml
+++ b/.github/workflows/trunk_upgrade.yml
@@ -6,7 +6,12 @@ on:
     # Runs 1st of every month
     - cron: 0 0 1 * *
 
-permissions: read-all
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   trunk_upgrade:
@@ -18,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit


### PR DESCRIPTION
## Summary
- Replace workflow-level `read-all` / write tokens with least-privilege `contents: read`, scoping write and OIDC permissions to the jobs that need them
- Add concurrency to `trunk_upgrade` and document publish/audit job permissions so `zizmor --persona pedantic` is clean
- Set `persist-credentials: false` on checkout steps across the touched workflows

## Test plan
- [ ] `zizmor .github/workflows --persona pedantic` reports no findings
- [ ] `zizmor .github/workflows` still exits 0
- [ ] CI jobs on this PR (build, test, trunk check) complete successfully with the tightened permissions


Made with [Cursor](https://cursor.com)