### PR TITLE
fix(security): remediate audit findings for hono and brace-expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "license": "Apache-2.0",
   "author": "yu-iskw",
   "scripts": {
+    "audit:all": "pnpm -r audit",
+    "audit:fix": "pnpm -r audit --fix update",
     "prebuild": "pnpm validate:names",
     "build": "pnpm --recursive build",
     "format": "pnpm exec trunk fmt",
@@ -19,7 +21,7 @@
     "format:trunk-all": "pnpm exec trunk fmt --all",
     "knip": "knip",
     "knip:fix": "knip --fix",
-    "lint": "pnpm exec trunk check && pnpm knip",
+    "lint": "pnpm exec trunk check && pnpm knip && pnpm audit:all",
     "lint:all": "pnpm lint:trunk-all",
     "lint:eslint": "eslint .",
     "lint:local": "pnpm lint:package-json && pnpm lint:prettier && pnpm lint:eslint && pnpm knip",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -30,7 +30,7 @@
     "@modelcontextprotocol/node": "2.0.0",
     "@modelcontextprotocol/server": "2.0.0",
     "commander": "^15.0.0",
-    "hono": "^4.12.32",
+    "hono": "^4.13.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,7 +101,7 @@ importers:
         specifier: workspace:*
         version: link:../common
       axios:
-        specifier: '>=1.18.0'
+        specifier: ^1.19.0
         version: 1.19.0(supports-color@10.2.2)
       bottleneck:
         specifier: ^2.19.5
@@ -137,7 +137,7 @@ importers:
         version: link:../common
       '@modelcontextprotocol/node':
         specifier: 2.0.0
-        version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.12.32)
+        version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.13.0)
       '@modelcontextprotocol/server':
         specifier: 2.0.0
         version: 2.0.0
@@ -145,8 +145,8 @@ importers:
         specifier: ^15.0.0
         version: 15.0.0
       hono:
-        specifier: ^4.12.32
-        version: 4.12.32
+        specifier: ^4.13.0
+        version: 4.13.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -1028,8 +1028,8 @@ packages:
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   browserslist@4.28.2:
@@ -1399,8 +1399,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.32:
-    resolution: {integrity: sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==}
+  hono@4.13.0:
+    resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -2175,9 +2175,9 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@hono/node-server@2.0.12(hono@4.12.32)':
+  '@hono/node-server@2.0.12(hono@4.13.0)':
     dependencies:
-      hono: 4.12.32
+      hono: 4.13.0
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -2222,12 +2222,12 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@modelcontextprotocol/node@2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.12.32)':
+  '@modelcontextprotocol/node@2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.13.0)':
     dependencies:
-      '@hono/node-server': 2.0.12(hono@4.12.32)
+      '@hono/node-server': 2.0.12(hono@4.13.0)
       '@modelcontextprotocol/server': 2.0.0
     optionalDependencies:
-      hono: 4.12.32
+      hono: 4.13.0
 
   '@modelcontextprotocol/server@2.0.0':
     dependencies:
@@ -2825,7 +2825,7 @@ snapshots:
 
   bottleneck@2.19.5: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3202,7 +3202,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.32: {}
+  hono@4.13.0: {}
 
   html-escaper@2.0.2: {}
 
@@ -3408,7 +3408,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minipass@7.1.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,8 +101,8 @@ importers:
         specifier: workspace:*
         version: link:../common
       axios:
-        specifier: ^1.19.0
-        version: 1.19.0(supports-color@10.2.2)
+        specifier: '>=1.18.0'
+        version: 1.19.0
       bottleneck:
         specifier: ^2.19.5
         version: 2.19.5
@@ -2778,7 +2778,7 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  agent-base@6.0.2(supports-color@10.2.2):
+  agent-base@6.0.2:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -2807,11 +2807,11 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.19.0(supports-color@10.2.2):
+  axios@1.19.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1(supports-color@10.2.2)
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -3206,9 +3206,9 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  https-proxy-agent@5.0.1(supports-color@10.2.2):
+  https-proxy-agent@5.0.1:
     dependencies:
-      agent-base: 6.0.2(supports-color@10.2.2)
+      agent-base: 6.0.2
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,8 @@ minimumReleaseAgeExclude:
   - '@hono/node-server'
   - redis
   - '@redis/*'
+  - hono@4.12.34
+  - brace-expansion@5.0.9
 
 overrides:
   form-data: '>=4.0.6'


### PR DESCRIPTION
Bump hono to ^4.13.0, allow brace-expansion@5.0.9 past minimumReleaseAge, and wire pnpm audit into the lint gate so regressions fail closed.