### PR TITLE
chore: bump version to 0.12.0

### DIFF
--- a/.changes/0.12.0.
+++ b/.changes/0.12.0.
@@ -1,0 +1,3 @@
+## [0.12.0] - 2026-08-04
+### Bug Fixes
+* Remediate audit findings for hono and brace-expansion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.12.0] - 2026-08-04
+
+### Bug Fixes
+
+- Remediate audit findings for hono and brace-expansion.
+
 ## [0.11.0] - 2026-08-04
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "description": "",
   "keywords": [],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/cli",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "CLI for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,7 +36,7 @@ const program = new Command();
 program
   .name('lightdash-ai')
   .description('CLI for Lightdash AI')
-  .version('0.11.0')
+  .version('0.12.0')
   .option(
     '--safety-mode <mode>',
     'Safety mode (read-only, write-idempotent, write-destructive)',

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/client",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Client library for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/common",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Shared utilities and types for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/mcp",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "MCP server for Lightdash semantic-layer, organization-audit, content-reader, content-developer, content-governance, and ai-agent-ops profiles.",
   "keywords": [],
   "repository": {

--- a/packages/mcp/src/bin.ts
+++ b/packages/mcp/src/bin.ts
@@ -54,7 +54,7 @@ program
   .description(
     `MCP server for Lightdash (${PROFILE_IDS.join(', ')}). Default stdio profile is ${DEFAULT_STDIO_PROFILE}.`,
   )
-  .version('0.11.0');
+  .version('0.12.0');
 
 program
   .command('stdio', { isDefault: true })


### PR DESCRIPTION
## Summary
- Bump root and workspace packages (`cli`, `client`, `common`, `mcp`) from 0.11.0 to 0.12.0
- Sync CLI/MCP `.version()` strings and Changie changelog for 0.12.0 (security audit remediation note)

## Test plan
- [ ] Confirm all `package.json` versions and CLI/MCP entrypoint `.version()` strings are `0.12.0`
- [ ] Confirm `CHANGELOG.md` has a `[0.12.0]` section
- [ ] CI passes on this draft PR before marking ready for review


Made with [Cursor](https://cursor.com)