### PR TITLE
feat(mcp): add request-scoped operation progress notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,7 @@ Additional specialized skills are documented in `CLAUDE.md`.
 - `pnpm -r version` needs a clean tree — bump `packages/*/package.json` versions directly if dirty.
 - Agent surface: MCP profiles own mounts via `tools: ToolModule[]` imports (ADR-0022); irrecoverable tool ids stay on `IRRECOVERABLE_TOOL_DENYLIST` (ADR-0004).
 - MCP: `registerToolSafe()` only; CLI: `wrapAction()`; serving profile via `bindServerProfile` + profile `tools` array.
+- MCP progress (SDK v2): emit via `ctx.mcpReq.notify` when `mcpReq._meta.progressToken` is set — there is no top-level `sendNotification` on `ServerContext` (ADR-0023).
 - Guardrails return `_lightdashBlocked`; upstream failures are coded `UPSTREAM_*` / `RATE_LIMITED`, not blocked markers.
 - Env: `LIGHTDASH_TOOLS_*`; shared allowlist `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS`; obsolete allowlist names fail closed. MCP HTTP listen: `LIGHTDASH_TOOLS_MCP_HTTP_PORT`, else platform `PORT` (Cloud Run), else `3100`. Launch via `npx`/`pnpm dlx`/`lightdash-mcp` — not `pnpm exec @lightdash-tools/mcp`.
 - Stdio: `lightdash-mcp stdio --profile <id>` only — no default; `http` mounts all profiles.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ Use the `/improve-claude-config` skill to orchestrate deeper changes.
 
 ## Recent Learnings
 
+- [2026-08-05]: MCP SDK v2 progress uses `ctx.mcpReq.notify({ method: 'notifications/progress', params })` with `mcpReq._meta.progressToken`; a top-level `sendNotification` on `ServerContext` does not exist and silently no-ops reporters that look for it.
 - [2026-08-04]: MCP mounts are profile-owned `ToolModule` imports (ADR-0022). Export `defineTool` / `defineToolVariant` beside handlers; profiles import those modules; `registry.ts` is denylist + `registerTools` only — not a second catalog.
 - [2026-08-04]: MCP stdio is transport-first — `lightdash-mcp stdio --profile <id>` (required); bare invoke fails closed; `http` for Streamable HTTP.
 - [2026-08-04]: `AGENTS.md` Common Gotchas is capped at ≤30 lines (pointer hub + traps). Profile/ADR essays belong in `docs/adr` and `docs/profiles`; replace obsolete bullets instead of appending forever.

--- a/docs/adr/0023-request-scoped-mcp-operation-notifications.md
+++ b/docs/adr/0023-request-scoped-mcp-operation-notifications.md
@@ -1,0 +1,36 @@
+# ADR-0023: Request-scoped MCP operation notifications
+
+- Status: Proposed
+- Date: 2026-08-05
+
+## Context
+
+MCP clients should be able to observe meaningful progress while Lightdash tools execute. The MCP progress protocol is request-scoped: clients opt in by attaching a progress token, after which the server may emit `notifications/progress` messages.
+
+Directly coupling the reusable Lightdash client to MCP would make package boundaries harder to maintain and would not help CLI or telemetry consumers.
+
+## Decision
+
+Introduce a transport-neutral `OperationReporter` in the MCP package and expose it through `ToolExecutionContext`.
+
+The MCP adapter:
+
+- reads the request progress token;
+- emits monotonic `notifications/progress` messages;
+- degrades to a no-op when no token is supplied;
+- treats notification delivery as best-effort;
+- never exposes raw URLs, SQL, credentials, headers, or response bodies.
+
+Tools using `wrapToolContextual` may report semantic phases such as `preparing`, `calling-service`, `waiting`, `processing-response`, and `completed`.
+
+## Consequences
+
+- Existing tools remain source-compatible unless they construct `ToolExecutionContext` directly.
+- Simple tools using `wrapTool` continue unchanged.
+- Contextual tools can adopt progress incrementally.
+- MCP transport details remain outside `@lightdash-tools/client`.
+- Clients that do not support progress continue to receive normal tool results.
+
+## Follow-up
+
+Instrument selected long-running tools first, measure client rendering behavior, and then decide whether to add Lightdash HTTP observer hooks and OpenTelemetry adapters.

--- a/packages/mcp/src/notifications/operation-reporter.test.ts
+++ b/packages/mcp/src/notifications/operation-reporter.test.ts
@@ -6,8 +6,10 @@ import type { ServerContext } from '@modelcontextprotocol/server';
 
 describe('createOperationReporter', () => {
   it('is a no-op when the client did not provide a progress token', async () => {
-    const sendNotification = vi.fn();
-    const reporter = createOperationReporter({ sendNotification } as unknown as ServerContext);
+    const notify = vi.fn();
+    const reporter = createOperationReporter({
+      mcpReq: { notify },
+    } as unknown as ServerContext);
 
     await reporter.phase({
       phase: 'preparing',
@@ -15,14 +17,27 @@ describe('createOperationReporter', () => {
       message: 'Preparing to list explores',
     });
 
-    expect(sendNotification).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when notify is missing even if a progress token is present', async () => {
+    const reporter = createOperationReporter({
+      mcpReq: { _meta: { progressToken: 'progress-1' } },
+    } as unknown as ServerContext);
+
+    await expect(
+      reporter.phase({
+        phase: 'preparing',
+        operation: 'list explores',
+        message: 'Preparing to list explores',
+      }),
+    ).resolves.toBeUndefined();
   });
 
   it('sends monotonic progress notifications for a request-scoped token', async () => {
-    const sendNotification = vi.fn().mockResolvedValue(undefined);
+    const notify = vi.fn().mockResolvedValue(undefined);
     const reporter = createOperationReporter({
-      mcpReq: { _meta: { progressToken: 'progress-1' } },
-      sendNotification,
+      mcpReq: { _meta: { progressToken: 'progress-1' }, notify },
     } as unknown as ServerContext);
 
     await reporter.phase({
@@ -40,7 +55,7 @@ describe('createOperationReporter', () => {
       totalUnits: 4,
     });
 
-    expect(sendNotification).toHaveBeenNthCalledWith(1, {
+    expect(notify).toHaveBeenNthCalledWith(1, {
       method: 'notifications/progress',
       params: {
         progressToken: 'progress-1',
@@ -49,7 +64,7 @@ describe('createOperationReporter', () => {
         message: 'Preparing to list explores',
       },
     });
-    expect(sendNotification).toHaveBeenNthCalledWith(2, {
+    expect(notify).toHaveBeenNthCalledWith(2, {
       method: 'notifications/progress',
       params: {
         progressToken: 'progress-1',
@@ -62,8 +77,10 @@ describe('createOperationReporter', () => {
 
   it('does not fail the operation when notification delivery fails', async () => {
     const reporter = createOperationReporter({
-      mcpReq: { _meta: { progressToken: 7 } },
-      sendNotification: vi.fn().mockRejectedValue(new Error('disconnected')),
+      mcpReq: {
+        _meta: { progressToken: 7 },
+        notify: vi.fn().mockRejectedValue(new Error('disconnected')),
+      },
     } as unknown as ServerContext);
 
     await expect(

--- a/packages/mcp/src/notifications/operation-reporter.test.ts
+++ b/packages/mcp/src/notifications/operation-reporter.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createOperationReporter } from './operation-reporter.js';
+
+import type { ServerContext } from '@modelcontextprotocol/server';
+
+describe('createOperationReporter', () => {
+  it('is a no-op when the client did not provide a progress token', async () => {
+    const sendNotification = vi.fn();
+    const reporter = createOperationReporter({ sendNotification } as unknown as ServerContext);
+
+    await reporter.phase({
+      phase: 'preparing',
+      operation: 'list explores',
+      message: 'Preparing to list explores',
+    });
+
+    expect(sendNotification).not.toHaveBeenCalled();
+  });
+
+  it('sends monotonic progress notifications for a request-scoped token', async () => {
+    const sendNotification = vi.fn().mockResolvedValue(undefined);
+    const reporter = createOperationReporter({
+      mcpReq: { _meta: { progressToken: 'progress-1' } },
+      sendNotification,
+    } as unknown as ServerContext);
+
+    await reporter.phase({
+      phase: 'preparing',
+      operation: 'list explores',
+      message: 'Preparing to list explores',
+      completedUnits: 1,
+      totalUnits: 4,
+    });
+    await reporter.phase({
+      phase: 'calling-service',
+      operation: 'list explores',
+      message: 'Loading explores from Lightdash',
+      completedUnits: 1,
+      totalUnits: 4,
+    });
+
+    expect(sendNotification).toHaveBeenNthCalledWith(1, {
+      method: 'notifications/progress',
+      params: {
+        progressToken: 'progress-1',
+        progress: 1,
+        total: 4,
+        message: 'Preparing to list explores',
+      },
+    });
+    expect(sendNotification).toHaveBeenNthCalledWith(2, {
+      method: 'notifications/progress',
+      params: {
+        progressToken: 'progress-1',
+        progress: 2,
+        total: 4,
+        message: 'Loading explores from Lightdash',
+      },
+    });
+  });
+
+  it('does not fail the operation when notification delivery fails', async () => {
+    const reporter = createOperationReporter({
+      mcpReq: { _meta: { progressToken: 7 } },
+      sendNotification: vi.fn().mockRejectedValue(new Error('disconnected')),
+    } as unknown as ServerContext);
+
+    await expect(
+      reporter.phase({
+        phase: 'waiting',
+        operation: 'run query',
+        message: 'Waiting for Lightdash',
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/mcp/src/notifications/operation-reporter.ts
+++ b/packages/mcp/src/notifications/operation-reporter.ts
@@ -1,11 +1,7 @@
 import type { ServerContext } from '@modelcontextprotocol/server';
 
 export type OperationPhase =
-  | 'calling-service'
-  | 'completed'
-  | 'preparing'
-  | 'processing-response'
-  | 'waiting';
+  'calling-service' | 'completed' | 'preparing' | 'processing-response' | 'waiting';
 
 export type OperationPhaseEvent = {
   phase: OperationPhase;
@@ -36,8 +32,8 @@ type ProgressCapableContext = ServerContext & {
     _meta?: {
       progressToken?: ProgressToken;
     };
+    notify?: (notification: ProgressNotification) => Promise<void>;
   };
-  sendNotification?: (notification: ProgressNotification) => Promise<void>;
 };
 
 class NoopOperationReporter implements OperationReporter {
@@ -51,9 +47,7 @@ class McpProgressOperationReporter implements OperationReporter {
 
   constructor(
     private readonly token: ProgressToken,
-    private readonly sendNotification: (
-      notification: ProgressNotification,
-    ) => Promise<void>,
+    private readonly notify: (notification: ProgressNotification) => Promise<void>,
   ) {}
 
   async phase(event: OperationPhaseEvent): Promise<void> {
@@ -70,23 +64,22 @@ class McpProgressOperationReporter implements OperationReporter {
     }
 
     try {
-      await this.sendNotification({ method: 'notifications/progress', params });
+      await this.notify({ method: 'notifications/progress', params });
     } catch {
       // Progress reporting is best-effort and must never fail the tool invocation.
     }
   }
 }
 
-export function createOperationReporter(
-  context: ServerContext | undefined,
-): OperationReporter {
+export function createOperationReporter(context: ServerContext | undefined): OperationReporter {
   const progressContext = context as ProgressCapableContext | undefined;
-  const token = progressContext?.mcpReq?._meta?.progressToken;
-  const sendNotification = progressContext?.sendNotification;
+  const mcpReq = progressContext?.mcpReq;
+  const token = mcpReq?._meta?.progressToken;
+  const notify = mcpReq?.notify;
 
-  if (token === undefined || sendNotification === undefined) {
+  if (token === undefined || notify === undefined) {
     return new NoopOperationReporter();
   }
 
-  return new McpProgressOperationReporter(token, sendNotification.bind(progressContext));
+  return new McpProgressOperationReporter(token, notify.bind(mcpReq));
 }

--- a/packages/mcp/src/notifications/operation-reporter.ts
+++ b/packages/mcp/src/notifications/operation-reporter.ts
@@ -1,11 +1,11 @@
 import type { ServerContext } from '@modelcontextprotocol/server';
 
 export type OperationPhase =
-  | 'preparing'
   | 'calling-service'
-  | 'waiting'
+  | 'completed'
+  | 'preparing'
   | 'processing-response'
-  | 'completed';
+  | 'waiting';
 
 export type OperationPhaseEvent = {
   phase: OperationPhase;
@@ -19,7 +19,7 @@ export interface OperationReporter {
   phase(event: OperationPhaseEvent): Promise<void>;
 }
 
-type ProgressToken = string | number;
+type ProgressToken = number | string;
 
 type ProgressNotification = {
   method: 'notifications/progress';
@@ -51,7 +51,9 @@ class McpProgressOperationReporter implements OperationReporter {
 
   constructor(
     private readonly token: ProgressToken,
-    private readonly sendNotification: (notification: ProgressNotification) => Promise<void>,
+    private readonly sendNotification: (
+      notification: ProgressNotification,
+    ) => Promise<void>,
   ) {}
 
   async phase(event: OperationPhaseEvent): Promise<void> {

--- a/packages/mcp/src/notifications/operation-reporter.ts
+++ b/packages/mcp/src/notifications/operation-reporter.ts
@@ -1,0 +1,90 @@
+import type { ServerContext } from '@modelcontextprotocol/server';
+
+export type OperationPhase =
+  | 'preparing'
+  | 'calling-service'
+  | 'waiting'
+  | 'processing-response'
+  | 'completed';
+
+export type OperationPhaseEvent = {
+  phase: OperationPhase;
+  operation: string;
+  message: string;
+  completedUnits?: number;
+  totalUnits?: number;
+};
+
+export interface OperationReporter {
+  phase(event: OperationPhaseEvent): Promise<void>;
+}
+
+type ProgressToken = string | number;
+
+type ProgressNotification = {
+  method: 'notifications/progress';
+  params: {
+    progressToken: ProgressToken;
+    progress: number;
+    total?: number;
+    message?: string;
+  };
+};
+
+type ProgressCapableContext = ServerContext & {
+  mcpReq?: {
+    _meta?: {
+      progressToken?: ProgressToken;
+    };
+  };
+  sendNotification?: (notification: ProgressNotification) => Promise<void>;
+};
+
+class NoopOperationReporter implements OperationReporter {
+  async phase(): Promise<void> {
+    // Intentionally empty when the client did not opt in to progress notifications.
+  }
+}
+
+class McpProgressOperationReporter implements OperationReporter {
+  private current = 0;
+
+  constructor(
+    private readonly token: ProgressToken,
+    private readonly sendNotification: (notification: ProgressNotification) => Promise<void>,
+  ) {}
+
+  async phase(event: OperationPhaseEvent): Promise<void> {
+    const requestedProgress = event.completedUnits ?? this.current + 1;
+    this.current = Math.max(this.current + 1, requestedProgress);
+
+    const params: ProgressNotification['params'] = {
+      progressToken: this.token,
+      progress: this.current,
+      message: event.message,
+    };
+    if (event.totalUnits !== undefined) {
+      params.total = event.totalUnits;
+    }
+
+    try {
+      await this.sendNotification({ method: 'notifications/progress', params });
+    } catch {
+      // Progress reporting is best-effort and must never fail the tool invocation.
+    }
+  }
+}
+
+export function createOperationReporter(
+  context: ServerContext | undefined,
+): OperationReporter {
+  const progressContext = context as ProgressCapableContext | undefined;
+  const token = progressContext?.mcpReq?._meta?.progressToken;
+  const sendNotification = progressContext?.sendNotification;
+
+  if (token === undefined || sendNotification === undefined) {
+    return new NoopOperationReporter();
+  }
+
+  return new McpProgressOperationReporter(token, sendNotification.bind(progressContext));
+}

--- a/packages/mcp/src/tools/shared.ts
+++ b/packages/mcp/src/tools/shared.ts
@@ -31,10 +31,10 @@ import { getPinnedProjectUuid } from '../governance/project-pin.js';
 import { createOperationReporter } from '../notifications/operation-reporter.js';
 import { classifyUpstreamError } from '../server/upstream-errors.js';
 
+import type { OperationReporter } from '../notifications/operation-reporter.js';
 import type { McpContextProvider } from '../server/request-context.js';
 import type { LightdashClient } from '@lightdash-tools/client';
 import type { AuditStatus, ToolAnnotations } from '@lightdash-tools/common';
-import type { OperationReporter } from '../notifications/operation-reporter.js';
 import type { InputRequiredResult, ServerContext } from '@modelcontextprotocol/server';
 import type { z } from 'zod';
 

--- a/packages/mcp/src/tools/shared.ts
+++ b/packages/mcp/src/tools/shared.ts
@@ -28,11 +28,13 @@ import {
   runWithMcpClientSessionAsync,
 } from '../governance/mcp-client-session.js';
 import { getPinnedProjectUuid } from '../governance/project-pin.js';
+import { createOperationReporter } from '../notifications/operation-reporter.js';
 import { classifyUpstreamError } from '../server/upstream-errors.js';
 
 import type { McpContextProvider } from '../server/request-context.js';
 import type { LightdashClient } from '@lightdash-tools/client';
 import type { AuditStatus, ToolAnnotations } from '@lightdash-tools/common';
+import type { OperationReporter } from '../notifications/operation-reporter.js';
 import type { InputRequiredResult, ServerContext } from '@modelcontextprotocol/server';
 import type { z } from 'zod';
 
@@ -323,6 +325,8 @@ export function registerToolSafe(
 
 export type ToolExecutionContext = {
   lightdashClient: LightdashClient;
+  /** Request-scoped reporter backed by MCP progress notifications when available. */
+  operationReporter: OperationReporter;
   /** SDK ServerContext when the transport provides it (second registerTool arg). */
   serverContext: ServerContext | undefined;
   sessionId: string;
@@ -348,13 +352,15 @@ export function wrapToolContextual<T>(
       return await runWithMcpClientSessionAsync(sessionId, async () => {
         const context = await contextProvider.getContext(extra);
         const auth = context.auth;
+        const serverContext = asServerContext(extra);
 
         return await runWithToolAuditAuthAsync(
           { tokenHash: auth?.tokenHash, subject: auth?.subject },
           async () => {
             const execution: ToolExecutionContext = {
               lightdashClient: context.lightdashClient,
-              serverContext: asServerContext(extra),
+              operationReporter: createOperationReporter(serverContext),
+              serverContext,
               sessionId,
               subject: auth?.subject ?? 'anonymous',
             };


### PR DESCRIPTION
## Summary

Implements the first production-grade slice of request-scoped MCP operation notifications described by the RFC.

### Changes

- add a transport-neutral `OperationReporter` abstraction;
- emit monotonic `notifications/progress` messages when clients provide a progress token;
- degrade to a no-op for clients without progress support;
- ensure notification delivery failures never fail tool execution;
- expose the reporter through `ToolExecutionContext` for incremental adoption by contextual tools;
- add unit coverage for opt-in behavior, monotonicity, and failure isolation;
- add ADR-0023 documenting the decision and rollout direction.

## Design notes

This PR intentionally does **not** couple `@lightdash-tools/client` to MCP and does not stream raw HTTP request data. Tool implementations should emit semantic, sanitized lifecycle messages.

## Follow-up work

- instrument selected long-running semantic-query and AI-agent tools;
- validate rendering behavior in Claude Code, Cursor, and Codex;
- consider an HTTP observer and OpenTelemetry adapter after the pilot.

## Validation

The implementation includes focused Vitest coverage. CI should run the repository's normal build, test, and lint checks.
