### PR TITLE
fix(mcp): emit progress via mcpReq.notify

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,7 @@ Additional specialized skills are documented in `CLAUDE.md`.
 - `pnpm -r version` needs a clean tree — bump `packages/*/package.json` versions directly if dirty.
 - Agent surface: MCP profiles own mounts via `tools: ToolModule[]` imports (ADR-0022); irrecoverable tool ids stay on `IRRECOVERABLE_TOOL_DENYLIST` (ADR-0004).
 - MCP: `registerToolSafe()` only; CLI: `wrapAction()`; serving profile via `bindServerProfile` + profile `tools` array.
+- MCP progress (SDK v2): emit via `ctx.mcpReq.notify` when `mcpReq._meta.progressToken` is set — there is no top-level `sendNotification` on `ServerContext` (ADR-0023).
 - Guardrails return `_lightdashBlocked`; upstream failures are coded `UPSTREAM_*` / `RATE_LIMITED`, not blocked markers.
 - Env: `LIGHTDASH_TOOLS_*`; shared allowlist `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS`; obsolete allowlist names fail closed. MCP HTTP listen: `LIGHTDASH_TOOLS_MCP_HTTP_PORT`, else platform `PORT` (Cloud Run), else `3100`. Launch via `npx`/`pnpm dlx`/`lightdash-mcp` — not `pnpm exec @lightdash-tools/mcp`.
 - Stdio: `lightdash-mcp stdio --profile <id>` only — no default; `http` mounts all profiles.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ Use the `/improve-claude-config` skill to orchestrate deeper changes.
 
 ## Recent Learnings
 
+- [2026-08-05]: MCP SDK v2 progress uses `ctx.mcpReq.notify({ method: 'notifications/progress', params })` with `mcpReq._meta.progressToken`; a top-level `sendNotification` on `ServerContext` does not exist and silently no-ops reporters that look for it.
 - [2026-08-04]: MCP mounts are profile-owned `ToolModule` imports (ADR-0022). Export `defineTool` / `defineToolVariant` beside handlers; profiles import those modules; `registry.ts` is denylist + `registerTools` only — not a second catalog.
 - [2026-08-04]: MCP stdio is transport-first — `lightdash-mcp stdio --profile <id>` (required); bare invoke fails closed; `http` for Streamable HTTP.
 - [2026-08-04]: `AGENTS.md` Common Gotchas is capped at ≤30 lines (pointer hub + traps). Profile/ADR essays belong in `docs/adr` and `docs/profiles`; replace obsolete bullets instead of appending forever.

--- a/packages/mcp/src/notifications/operation-reporter.test.ts
+++ b/packages/mcp/src/notifications/operation-reporter.test.ts
@@ -6,8 +6,10 @@ import type { ServerContext } from '@modelcontextprotocol/server';
 
 describe('createOperationReporter', () => {
   it('is a no-op when the client did not provide a progress token', async () => {
-    const sendNotification = vi.fn();
-    const reporter = createOperationReporter({ sendNotification } as unknown as ServerContext);
+    const notify = vi.fn();
+    const reporter = createOperationReporter({
+      mcpReq: { notify },
+    } as unknown as ServerContext);
 
     await reporter.phase({
       phase: 'preparing',
@@ -15,14 +17,27 @@ describe('createOperationReporter', () => {
       message: 'Preparing to list explores',
     });
 
-    expect(sendNotification).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when notify is missing even if a progress token is present', async () => {
+    const reporter = createOperationReporter({
+      mcpReq: { _meta: { progressToken: 'progress-1' } },
+    } as unknown as ServerContext);
+
+    await expect(
+      reporter.phase({
+        phase: 'preparing',
+        operation: 'list explores',
+        message: 'Preparing to list explores',
+      }),
+    ).resolves.toBeUndefined();
   });
 
   it('sends monotonic progress notifications for a request-scoped token', async () => {
-    const sendNotification = vi.fn().mockResolvedValue(undefined);
+    const notify = vi.fn().mockResolvedValue(undefined);
     const reporter = createOperationReporter({
-      mcpReq: { _meta: { progressToken: 'progress-1' } },
-      sendNotification,
+      mcpReq: { _meta: { progressToken: 'progress-1' }, notify },
     } as unknown as ServerContext);
 
     await reporter.phase({
@@ -40,7 +55,7 @@ describe('createOperationReporter', () => {
       totalUnits: 4,
     });
 
-    expect(sendNotification).toHaveBeenNthCalledWith(1, {
+    expect(notify).toHaveBeenNthCalledWith(1, {
       method: 'notifications/progress',
       params: {
         progressToken: 'progress-1',
@@ -49,7 +64,7 @@ describe('createOperationReporter', () => {
         message: 'Preparing to list explores',
       },
     });
-    expect(sendNotification).toHaveBeenNthCalledWith(2, {
+    expect(notify).toHaveBeenNthCalledWith(2, {
       method: 'notifications/progress',
       params: {
         progressToken: 'progress-1',
@@ -62,8 +77,10 @@ describe('createOperationReporter', () => {
 
   it('does not fail the operation when notification delivery fails', async () => {
     const reporter = createOperationReporter({
-      mcpReq: { _meta: { progressToken: 7 } },
-      sendNotification: vi.fn().mockRejectedValue(new Error('disconnected')),
+      mcpReq: {
+        _meta: { progressToken: 7 },
+        notify: vi.fn().mockRejectedValue(new Error('disconnected')),
+      },
     } as unknown as ServerContext);
 
     await expect(

--- a/packages/mcp/src/notifications/operation-reporter.ts
+++ b/packages/mcp/src/notifications/operation-reporter.ts
@@ -36,8 +36,8 @@ type ProgressCapableContext = ServerContext & {
     _meta?: {
       progressToken?: ProgressToken;
     };
+    notify?: (notification: ProgressNotification) => Promise<void>;
   };
-  sendNotification?: (notification: ProgressNotification) => Promise<void>;
 };
 
 class NoopOperationReporter implements OperationReporter {
@@ -51,9 +51,7 @@ class McpProgressOperationReporter implements OperationReporter {
 
   constructor(
     private readonly token: ProgressToken,
-    private readonly sendNotification: (
-      notification: ProgressNotification,
-    ) => Promise<void>,
+    private readonly notify: (notification: ProgressNotification) => Promise<void>,
   ) {}
 
   async phase(event: OperationPhaseEvent): Promise<void> {
@@ -70,7 +68,7 @@ class McpProgressOperationReporter implements OperationReporter {
     }
 
     try {
-      await this.sendNotification({ method: 'notifications/progress', params });
+      await this.notify({ method: 'notifications/progress', params });
     } catch {
       // Progress reporting is best-effort and must never fail the tool invocation.
     }
@@ -81,12 +79,13 @@ export function createOperationReporter(
   context: ServerContext | undefined,
 ): OperationReporter {
   const progressContext = context as ProgressCapableContext | undefined;
-  const token = progressContext?.mcpReq?._meta?.progressToken;
-  const sendNotification = progressContext?.sendNotification;
+  const mcpReq = progressContext?.mcpReq;
+  const token = mcpReq?._meta?.progressToken;
+  const notify = mcpReq?.notify;
 
-  if (token === undefined || sendNotification === undefined) {
+  if (token === undefined || notify === undefined) {
     return new NoopOperationReporter();
   }
 
-  return new McpProgressOperationReporter(token, sendNotification.bind(progressContext));
+  return new McpProgressOperationReporter(token, notify.bind(mcpReq));
 }

--- a/packages/mcp/src/notifications/operation-reporter.ts
+++ b/packages/mcp/src/notifications/operation-reporter.ts
@@ -1,11 +1,7 @@
 import type { ServerContext } from '@modelcontextprotocol/server';
 
 export type OperationPhase =
-  | 'calling-service'
-  | 'completed'
-  | 'preparing'
-  | 'processing-response'
-  | 'waiting';
+  'calling-service' | 'completed' | 'preparing' | 'processing-response' | 'waiting';
 
 export type OperationPhaseEvent = {
   phase: OperationPhase;
@@ -75,9 +71,7 @@ class McpProgressOperationReporter implements OperationReporter {
   }
 }
 
-export function createOperationReporter(
-  context: ServerContext | undefined,
-): OperationReporter {
+export function createOperationReporter(context: ServerContext | undefined): OperationReporter {
   const progressContext = context as ProgressCapableContext | undefined;
   const mcpReq = progressContext?.mcpReq;
   const token = mcpReq?._meta?.progressToken;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the Codex P2 review on #181: progress notifications were wired to a non-existent top-level `sendNotification`, so real MCP SDK v2 tool calls always fell into the no-op reporter.

## Changes

- Read the request-scoped sender from `context.mcpReq.notify` (MCP TypeScript SDK v2).
- Keep opt-in on `mcpReq._meta.progressToken` and best-effort delivery.
- Retarget unit tests to `mcpReq.notify`.
- Add coverage for token present but `notify` missing → no-op.
- Document the pitfall in `AGENTS.md` / `CLAUDE.md`.
- Prettier-format `operation-reporter.ts` (Trunk Check).

## Validation

- Local: `pnpm exec vitest run packages/mcp/src/notifications/operation-reporter.test.ts` — 4/4 passed
- CI: Build, Unit Tests, Trunk Check / Runner, OpenAPI Drift, SBOM, Socket — all green

Base: `feat/mcp-operation-notifications` (PR #181).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd0e9-5a27-7958-99ed-b48c85b9bf0a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd0e9-5a27-7958-99ed-b48c85b9bf0a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

