### PR TITLE
feat(mcp): add Compose healthcheck for /health/live

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,3 +15,13 @@ services:
       LIGHTDASH_TOOLS_MCP_HTTP_HOST: 0.0.0.0
       LIGHTDASH_TOOLS_MCP_HTTP_PORT: 8080
       # LIGHTDASH_TOOLS_MCP_PUBLIC_URL comes from .env (ephemeral *.trycloudflare.com host)
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - fetch('http://127.0.0.1:8080/health/live').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 15s

--- a/docs/operators/cursor-claude.md
+++ b/docs/operators/cursor-claude.md
@@ -51,7 +51,7 @@ Use Cloudflare quick tunnel so Cursor’s post-callback Mozilla GETs to PRM/AS m
 
 2. Copy the printed `https://*.trycloudflare.com` URL into gitignored `.env` as `LIGHTDASH_TOOLS_MCP_PUBLIC_URL`, and into `.cursor/mcp.json` as the MCP `url` host (`…/semantic-layer/v1/mcp`).
 
-3. Start (or recreate) MCP so it picks up `.env`:
+3. Start (or recreate) MCP so it picks up `.env`. Wait for `healthy` in `docker compose -f docker-compose.dev.yml ps` before relying on the tunnel:
 
    ```bash
    docker compose -f docker-compose.dev.yml up --build -d


### PR DESCRIPTION
Probe the public liveness endpoint with Node fetch so local docker compose reports healthy without PAT or OAuth credentials in the check.