### PR TITLE
refactor(common,client): remove dead public exports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,7 @@ Additional specialized skills are documented in `CLAUDE.md`.
 ## Common Gotchas
 
 - Use `pnpm` only (not npm/yarn). Enable Corepack if `pnpm` is missing.
+- Corepack: if you invoke commands via `corepack pnpm ...`, run `corepack enable` before repo scripts that shell out to nested `pnpm` (for example `pnpm build`), or those nested calls fail with `pnpm: not found`.
 - Trunk: `@trunkio/launcher` + `pnpm trunk:install`; restricted network → `pnpm lint:eslint` / `format:eslint` / `format:prettier`.
 - pnpm v11: `overrides` live in `pnpm-workspace.yaml`; keep lockfile committed; `packageManager` is `pnpm@11.5.3`.
 - Build before ESLint (`dist/` resolves); prefer root `pnpm exec vitest run <files>` over per-package `test:fast`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ Use the `/improve-claude-config` skill to orchestrate deeper changes.
 
 ## Recent Learnings
 
+- [2026-08-06]: `corepack pnpm <cmd>` does not guarantee nested `pnpm` invocations inside scripts resolve; run `corepack enable` first so script chains like `pnpm build` (which calls `pnpm validate:names`) do not fail with `pnpm: not found`.
 - [2026-08-05]: MCP SDK v2 progress uses `ctx.mcpReq.notify({ method: 'notifications/progress', params })` with `mcpReq._meta.progressToken`; a top-level `sendNotification` on `ServerContext` does not exist and silently no-ops reporters that look for it.
 - [2026-08-04]: MCP mounts are profile-owned `ToolModule` imports (ADR-0022). Export `defineTool` / `defineToolVariant` beside handlers; profiles import those modules; `registry.ts` is denylist + `registerTools` only — not a second catalog.
 - [2026-08-04]: MCP stdio is transport-first — `lightdash-mcp stdio --profile <id>` (required); bare invoke fails closed; `http` for Streamable HTTP.

--- a/knip.json
+++ b/knip.json
@@ -3,7 +3,7 @@
   "ignoreDependencies": [],
   "ignoreExportsUsedInFile": true,
   "ignoreIssues": {
-    "packages/common/src/types/**": [
+    "packages/common/src/types/generated/openapi-types.ts": [
       "exports",
       "types",
       "nsExports",
@@ -11,7 +11,38 @@
       "enumMembers",
       "namespaceMembers"
     ],
-    "packages/client/src/http/axios-client.ts": ["exports"]
+    "packages/common/src/types/v1/**": [
+      "exports",
+      "types",
+      "nsExports",
+      "nsTypes",
+      "enumMembers",
+      "namespaceMembers"
+    ],
+    "packages/common/src/types/v2/**": [
+      "exports",
+      "types",
+      "nsExports",
+      "nsTypes",
+      "enumMembers",
+      "namespaceMembers"
+    ],
+    "packages/common/src/types/lightdash-api.ts": [
+      "exports",
+      "types",
+      "nsExports",
+      "nsTypes",
+      "enumMembers",
+      "namespaceMembers"
+    ],
+    "packages/common/src/types/index.ts": [
+      "exports",
+      "types",
+      "nsExports",
+      "nsTypes",
+      "enumMembers",
+      "namespaceMembers"
+    ]
   },
   "workspaces": {
     ".": {

--- a/packages/client/src/http/axios-client.ts
+++ b/packages/client/src/http/axios-client.ts
@@ -52,11 +52,3 @@ export function createAxiosInstanceV1(config: ResolvedLightdashClientConfig): Ax
 export function createAxiosInstanceV2(config: ResolvedLightdashClientConfig): AxiosInstance {
   return createAxiosInstanceForVersion(config, 'v2');
 }
-
-/**
- * Creates a configured Axios instance for the Lightdash API v1.
- * @deprecated Use `createAxiosInstanceV1` instead. This function is kept for backward compatibility.
- */
-export function createAxiosInstance(config: ResolvedLightdashClientConfig): AxiosInstance {
-  return createAxiosInstanceV1(config);
-}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -93,12 +93,11 @@ export {
 export { HttpClient } from './http/http-client';
 export {
   isApiSuccessEnvelope,
-  unwrapApiSuccessResults,
   type ApiEnvelope,
   type ApiErrorEnvelope,
   type ApiSuccessEnvelope,
 } from './http/unwrap-api-success';
 export { RateLimiter } from './http/rate-limiter';
 export { SecretString } from './utils/secret-string';
-export type { ApiResponseOk, ApiResponseError, ApiResponseBody, ApiError } from './types/api';
+export type { ApiError } from './types/api';
 export type { paths, components, operations } from './types/api';

--- a/packages/client/src/types/api.ts
+++ b/packages/client/src/types/api.ts
@@ -1,8 +1,9 @@
 /**
- * Helper types for Lightdash API. Re-exports generated OpenAPI types and adds response helpers.
+ * Helper types for Lightdash API. Re-exports generated OpenAPI types.
  *
  * Note: Domain models (Project, Organization, etc.) are available from @lightdash-tools/common.
- * Use this module for advanced types (paths, components, operations) or response helpers.
+ * Use this module for advanced types (paths, components, operations).
+ * Response envelopes live in `http/unwrap-api-success` (re-exported from the package root).
  */
 
 import type { components } from '@lightdash-tools/common';
@@ -11,18 +12,3 @@ export type { paths, components, operations } from '@lightdash-tools/common';
 
 /** API error schema from OpenAPI. */
 export type ApiError = components['schemas']['ApiErrorPayload'];
-
-/** Successful API response wrapper (status ok + results). */
-export interface ApiResponseOk<T> {
-  status: 'ok';
-  results: T;
-}
-
-/** Failed API response wrapper (status error + error). */
-export interface ApiResponseError {
-  status: 'error';
-  error: ApiError['error'];
-}
-
-/** Discriminated union for API response body. */
-export type ApiResponseBody<T> = ApiResponseError | ApiResponseOk<T>;

--- a/packages/common/src/agentops/extract-yaml-project.ts
+++ b/packages/common/src/agentops/extract-yaml-project.ts
@@ -1,14 +1,5 @@
 import { parseLightdashAiAgentBundle, parseLightdashAiEvaluationGate } from './types';
 
-/** True when MCP tool args carry AgentOps YAML documents that imply a project scope. */
-export function hasYamlProjectDocumentArgs(args: unknown): boolean {
-  if (typeof args !== 'object' || args === null || Array.isArray(args)) {
-    return false;
-  }
-  const record = args as Record<string, unknown>;
-  return typeof record.bundleYaml === 'string' || typeof record.gateYaml === 'string';
-}
-
 /**
  * Extracts project UUIDs from MCP tool args, including YAML document fields
  * (`bundleYaml`, `gateYaml`) used by AgentOps composite tools.

--- a/packages/common/src/argument-validation.test.ts
+++ b/packages/common/src/argument-validation.test.ts
@@ -1,18 +1,12 @@
 import { describe, it, expect } from 'vitest';
 
-import {
-  RESOURCE_ID_KEYS,
-  validateArguments,
-  validateResourceIdsInObject,
-} from './argument-validation';
-
-import type { ArgumentDescriptor } from './argument-validation';
+import { RESOURCE_ID_KEYS, validateResourceIdsInObject } from './argument-validation';
 
 const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
 
 describe('argument-validation', () => {
   describe('RESOURCE_ID_KEYS', () => {
-    it('contains all RFC Phase 0 identifier keys', () => {
+    it('contains known resource identifier keys', () => {
       expect([...RESOURCE_ID_KEYS].sort()).toEqual(
         [
           'agentUuid',
@@ -54,106 +48,6 @@ describe('argument-validation', () => {
           'versionUuidA',
           'versionUuidB',
         ].sort(),
-      );
-    });
-  });
-
-  describe('validateArguments', () => {
-    it('validates uuid arguments', () => {
-      const descriptors: ArgumentDescriptor[] = [
-        { name: 'projectUuid', source: 'option', semanticType: 'uuid', required: true },
-      ];
-      expect(() => validateArguments({ projectUuid: VALID_UUID }, descriptors)).not.toThrow();
-      expect(() => validateArguments({ projectUuid: 'bad-uuid' }, descriptors)).toThrow(
-        'Invalid UUID format',
-      );
-    });
-
-    it('validates slug arguments', () => {
-      const descriptors: ArgumentDescriptor[] = [
-        { name: 'slug', source: 'option', semanticType: 'slug' },
-      ];
-      expect(() => validateArguments({ slug: 'my-chart' }, descriptors)).not.toThrow();
-      expect(() => validateArguments({ slug: 'bad slug' }, descriptors)).toThrow(
-        'Slug must contain only alphanumeric characters',
-      );
-    });
-
-    it('validates fingerprint arguments', () => {
-      const descriptors: ArgumentDescriptor[] = [
-        { name: 'fingerprint', source: 'body', semanticType: 'fingerprint' },
-      ];
-      expect(() => validateArguments({ fingerprint: 'abc123' }, descriptors)).not.toThrow();
-      expect(() => validateArguments({ fingerprint: '' }, descriptors)).toThrow(
-        'Fingerprint must be between 1 and 512 characters',
-      );
-    });
-
-    it('throws when required argument is missing', () => {
-      const descriptors: ArgumentDescriptor[] = [
-        { name: 'projectUuid', source: 'option', semanticType: 'uuid', required: true },
-      ];
-      expect(() => validateArguments({}, descriptors)).toThrow(
-        "Required argument 'projectUuid' is missing",
-      );
-    });
-
-    it('skips optional missing arguments', () => {
-      const descriptors: ArgumentDescriptor[] = [
-        { name: 'slug', source: 'option', semanticType: 'slug' },
-      ];
-      expect(() => validateArguments({}, descriptors)).not.toThrow();
-    });
-
-    it('validates uuid arrays', () => {
-      const descriptors: ArgumentDescriptor[] = [
-        { name: 'projectUuid', source: 'body', semanticType: 'uuid' },
-      ];
-      expect(() =>
-        validateArguments({ projectUuid: [VALID_UUID, VALID_UUID] }, descriptors),
-      ).not.toThrow();
-      expect(() =>
-        validateArguments({ projectUuid: [VALID_UUID, 'not-uuid'] }, descriptors),
-      ).toThrow('Invalid UUID format');
-    });
-
-    it('validates free-text with control char rejection only', () => {
-      const descriptors: ArgumentDescriptor[] = [
-        { name: 'query', source: 'positional', semanticType: 'free-text' },
-      ];
-      expect(() => validateArguments({ query: 'what? growth%' }, descriptors)).not.toThrow();
-      expect(() => validateArguments({ query: 'bad\u0000' }, descriptors)).toThrow(
-        'Input contains invalid control characters',
-      );
-    });
-
-    it('validates json string arguments', () => {
-      const descriptors: ArgumentDescriptor[] = [
-        { name: 'payload', source: 'body', semanticType: 'json' },
-      ];
-      expect(() => validateArguments({ payload: '{"a":1}' }, descriptors)).not.toThrow();
-      expect(() => validateArguments({ payload: 'not-json' }, descriptors)).toThrow(
-        "Argument 'payload' must be valid JSON",
-      );
-    });
-
-    it('validates boolean arguments', () => {
-      const descriptors: ArgumentDescriptor[] = [
-        { name: 'enabled', source: 'option', semanticType: 'boolean' },
-      ];
-      expect(() => validateArguments({ enabled: true }, descriptors)).not.toThrow();
-      expect(() => validateArguments({ enabled: 'true' }, descriptors)).toThrow(
-        "Argument 'enabled' must be a boolean",
-      );
-    });
-
-    it('validates number arguments', () => {
-      const descriptors: ArgumentDescriptor[] = [
-        { name: 'limit', source: 'option', semanticType: 'number' },
-      ];
-      expect(() => validateArguments({ limit: 10 }, descriptors)).not.toThrow();
-      expect(() => validateArguments({ limit: Number.NaN }, descriptors)).toThrow(
-        "Argument 'limit' must be a number",
       );
     });
   });

--- a/packages/common/src/argument-validation.ts
+++ b/packages/common/src/argument-validation.ts
@@ -1,10 +1,9 @@
 /**
- * Descriptor-driven argument validation for CLI and MCP tools (RFC Phase 0).
- * Validates known resource identifier keys with semantic type rules.
+ * Resource-identifier validation for CLI and MCP tools.
+ * Validates known resource identifier keys when walking tool/command argument objects.
  */
 
 import {
-  rejectControlChars,
   validateFingerprint,
   validateSlug,
   validateUuid,
@@ -63,113 +62,6 @@ const UUID_OR_SLUG_KEYS = new Set([
   'contentUuidOrSlug',
 ]);
 
-export type ArgumentSource = 'body' | 'option' | 'positional';
-
-export type ArgumentSemanticType =
-  'boolean' | 'fingerprint' | 'free-text' | 'json' | 'number' | 'slug' | 'uuid-or-slug' | 'uuid';
-
-/** Per-argument validation metadata supplied by CLI/MCP command definitions. */
-export interface ArgumentDescriptor {
-  name: string;
-  source: ArgumentSource;
-  semanticType: ArgumentSemanticType;
-  required?: boolean;
-}
-
-function isMissing(value: unknown): boolean {
-  return value === undefined || value === null;
-}
-
-function requireString(value: unknown, name: string, label: string): string {
-  if (typeof value !== 'string') {
-    throw new Error(`Argument '${name}' must be a string ${label}`);
-  }
-  return value;
-}
-
-function validateUuidArgument(value: unknown, name: string): void {
-  validateUuid(requireString(value, name, 'UUID'));
-}
-
-function validateSlugArgument(value: unknown, name: string): void {
-  validateSlug(requireString(value, name, 'slug'));
-}
-
-function validateFingerprintArgument(value: unknown, name: string): void {
-  validateFingerprint(requireString(value, name, 'fingerprint'));
-}
-
-function validateFreeTextArgument(value: unknown, _name: string): void {
-  if (typeof value === 'string') {
-    rejectControlChars(value);
-  }
-}
-
-function validateJsonArgument(value: unknown, name: string): void {
-  if (typeof value !== 'string') {
-    return;
-  }
-  rejectControlChars(value);
-  try {
-    JSON.parse(value);
-  } catch {
-    throw new Error(`Argument '${name}' must be valid JSON`);
-  }
-}
-
-function validateBooleanArgument(value: unknown, name: string): void {
-  if (typeof value !== 'boolean') {
-    throw new Error(`Argument '${name}' must be a boolean`);
-  }
-}
-
-function validateNumberArgument(value: unknown, name: string): void {
-  if (typeof value !== 'number' || Number.isNaN(value)) {
-    throw new Error(`Argument '${name}' must be a number`);
-  }
-}
-
-function validateUuidOrSlugArgument(value: unknown, name: string): void {
-  validateUuidOrSlug(requireString(value, name, 'UUID or slug'));
-}
-
-function validateBySemanticType(
-  value: unknown,
-  semanticType: ArgumentSemanticType,
-  name: string,
-): void {
-  switch (semanticType) {
-    case 'boolean':
-      validateBooleanArgument(value, name);
-      break;
-    case 'fingerprint':
-      validateFingerprintArgument(value, name);
-      break;
-    case 'free-text':
-      validateFreeTextArgument(value, name);
-      break;
-    case 'json':
-      validateJsonArgument(value, name);
-      break;
-    case 'number':
-      validateNumberArgument(value, name);
-      break;
-    case 'slug':
-      validateSlugArgument(value, name);
-      break;
-    case 'uuid':
-      validateUuidArgument(value, name);
-      break;
-    case 'uuid-or-slug':
-      validateUuidOrSlugArgument(value, name);
-      break;
-    default: {
-      const exhaustive: never = semanticType;
-      throw new Error(`Unknown semantic type: ${exhaustive}`);
-    }
-  }
-}
-
 function validateResourceIdValue(key: string, value: string): void {
   if (key === 'slug' || key === 'newSlug') {
     validateSlug(value);
@@ -197,33 +89,6 @@ function validateResourceIdValues(key: string, value: unknown): void {
         throw new Error(`Argument '${key}' must be a string or string array`);
       }
       validateResourceIdValue(key, item);
-    }
-  }
-}
-
-/**
- * Validates tool arguments against explicit descriptors.
- * Identifier semantic types (`uuid`, `slug`, `fingerprint`) receive strict validation.
- */
-export function validateArguments(
-  args: Record<string, unknown>,
-  descriptors: ArgumentDescriptor[],
-): void {
-  for (const descriptor of descriptors) {
-    const value = args[descriptor.name];
-    if (isMissing(value)) {
-      if (descriptor.required) {
-        throw new Error(`Required argument '${descriptor.name}' is missing`);
-      }
-      continue;
-    }
-
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        validateBySemanticType(item, descriptor.semanticType, descriptor.name);
-      }
-    } else {
-      validateBySemanticType(value, descriptor.semanticType, descriptor.name);
     }
   }
 }

--- a/packages/common/src/index.test.ts
+++ b/packages/common/src/index.test.ts
@@ -1,9 +1,0 @@
-import { describe, it, expect } from 'vitest';
-
-import { greet } from './index';
-
-describe('greet', () => {
-  it('should return a greeting message', () => {
-    expect(greet('World')).toBe('Hello, World!');
-  });
-});

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,7 +1,3 @@
-export function greet(name: string): string {
-  return `Hello, ${name}!`;
-}
-
 // Export env var constants
 export * from './env';
 
@@ -11,7 +7,7 @@ export * from './safety';
 // Export input validation
 export * from './input-validation';
 
-// Export argument / descriptor validation
+// Export argument / resource-id validation
 export * from './argument-validation';
 
 // MCP serving profile ids (shared with audit typing)
@@ -24,10 +20,7 @@ export * from './agent-safe';
 export * from './agentops/types';
 export * from './agentops/snapshots';
 export * from './agentops/formatters';
-export {
-  extractProjectUuidsFromToolArgs,
-  hasYamlProjectDocumentArgs,
-} from './agentops/extract-yaml-project';
+export { extractProjectUuidsFromToolArgs } from './agentops/extract-yaml-project';
 
 // Export audit logger (shared by MCP and CLI)
 export * from './audit';

--- a/packages/common/src/safety.test.ts
+++ b/packages/common/src/safety.test.ts
@@ -3,10 +3,8 @@ import { describe, it, expect, afterEach } from 'vitest';
 import {
   SafetyMode,
   isAllowed,
-  isOperationAllowed,
   getSafetyModeFromEnv,
   getAllowedProjectUuidsFromEnv,
-  isProjectAllowed,
   areAllProjectsAllowed,
   extractProjectUuids,
   READ_ONLY_DEFAULT,
@@ -14,25 +12,11 @@ import {
   WRITE_NONDESTRUCTIVE,
   WRITE_OPEN_WORLD,
   WRITE_DESTRUCTIVE,
-  type OperationPolicy,
-  type SafetyImpact,
 } from './safety';
 
 const UUID_A = '11111111-1111-1111-1111-111111111111';
 const UUID_B = '22222222-2222-2222-2222-222222222222';
 const UUID_C = '33333333-3333-3333-3333-333333333333';
-
-const ALL_IMPACTS: SafetyImpact[] = [
-  'read',
-  'write-nondestructive',
-  'write-destructive',
-  'credential-sensitive',
-  'external-side-effect',
-];
-
-function policy(impact: SafetyImpact): OperationPolicy {
-  return { impact };
-}
 
 describe('Safety Logic', () => {
   describe('annotation presets', () => {
@@ -133,52 +117,6 @@ describe('Safety Logic', () => {
     });
   });
 
-  describe('isOperationAllowed', () => {
-    it('should allow only read impact in read-only mode', () => {
-      expect(isOperationAllowed(SafetyMode.READ_ONLY, policy('read'))).toBe(true);
-      expect(isOperationAllowed(SafetyMode.READ_ONLY, policy('write-nondestructive'))).toBe(false);
-      expect(isOperationAllowed(SafetyMode.READ_ONLY, policy('write-destructive'))).toBe(false);
-      expect(isOperationAllowed(SafetyMode.READ_ONLY, policy('credential-sensitive'))).toBe(false);
-      expect(isOperationAllowed(SafetyMode.READ_ONLY, policy('external-side-effect'))).toBe(false);
-    });
-
-    it('should allow read, write-nondestructive, and external-side-effect in write-nondestructive mode', () => {
-      expect(isOperationAllowed(SafetyMode.WRITE_NONDESTRUCTIVE, policy('read'))).toBe(true);
-      expect(
-        isOperationAllowed(SafetyMode.WRITE_NONDESTRUCTIVE, policy('write-nondestructive')),
-      ).toBe(true);
-      expect(
-        isOperationAllowed(SafetyMode.WRITE_NONDESTRUCTIVE, policy('external-side-effect')),
-      ).toBe(true);
-      expect(isOperationAllowed(SafetyMode.WRITE_NONDESTRUCTIVE, policy('write-destructive'))).toBe(
-        false,
-      );
-      expect(
-        isOperationAllowed(SafetyMode.WRITE_NONDESTRUCTIVE, policy('credential-sensitive')),
-      ).toBe(false);
-    });
-
-    it('should treat write-idempotent mode the same as write-nondestructive for policy checks', () => {
-      for (const impact of ALL_IMPACTS) {
-        expect(isOperationAllowed(SafetyMode.WRITE_IDEMPOTENT, policy(impact))).toBe(
-          isOperationAllowed(SafetyMode.WRITE_NONDESTRUCTIVE, policy(impact)),
-        );
-      }
-    });
-
-    it('should allow all impacts in write-destructive mode', () => {
-      for (const impact of ALL_IMPACTS) {
-        expect(isOperationAllowed(SafetyMode.WRITE_DESTRUCTIVE, policy(impact))).toBe(true);
-      }
-    });
-
-    it('should fail closed for unknown mode strings', () => {
-      for (const impact of ALL_IMPACTS) {
-        expect(isOperationAllowed('custom-mode', policy(impact))).toBe(false);
-      }
-    });
-  });
-
   describe('getSafetyModeFromEnv', () => {
     const originalEnv = process.env.LIGHTDASH_TOOLS_SAFETY_MODE;
 
@@ -268,20 +206,6 @@ describe('Safety Logic', () => {
       expect(() => getAllowedProjectUuidsFromEnv()).toThrow(
         /LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS/,
       );
-    });
-  });
-
-  describe('isProjectAllowed', () => {
-    it('should allow all projects when allowlist is empty', () => {
-      expect(isProjectAllowed([], 'any-uuid')).toBe(true);
-    });
-
-    it('should allow a project that is in the allowlist', () => {
-      expect(isProjectAllowed(['uuid-a', 'uuid-b'], 'uuid-a')).toBe(true);
-    });
-
-    it('should deny a project that is not in the allowlist', () => {
-      expect(isProjectAllowed(['uuid-a', 'uuid-b'], 'uuid-c')).toBe(false);
     });
   });
 

--- a/packages/common/src/safety.ts
+++ b/packages/common/src/safety.ts
@@ -5,17 +5,6 @@ import { ENV_LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS, ENV_LIGHTDASH_TOOLS_SAFETY_M
 const ENV_ALLOWED_PROJECTS_REMOVED = 'LIGHTDASH_TOOLS_ALLOWED_PROJECTS';
 
 /**
- * Semantic impact classification for operations (RFC Phase 0).
- * Used by {@link OperationPolicy} and {@link isOperationAllowed}.
- */
-export type SafetyImpact =
-  | 'credential-sensitive'
-  | 'external-side-effect'
-  | 'read'
-  | 'write-destructive'
-  | 'write-nondestructive';
-
-/**
  * Hierarchical safety modes for Lightdash AI tools and CLI.
  */
 export enum SafetyMode {
@@ -36,11 +25,6 @@ export type ToolAnnotations = {
   destructiveHint?: boolean;
   idempotentHint?: boolean;
   openWorldHint?: boolean;
-};
-
-/** Policy describing the semantic impact of an operation. */
-export type OperationPolicy = {
-  impact: SafetyImpact;
 };
 
 /** Preset: read-only, non-destructive, idempotent, closed-world. Use for list/get/compile tools. */
@@ -116,28 +100,6 @@ export function isAllowed(mode: SafetyMode | string, annotations: ToolAnnotation
 }
 
 /**
- * Validates if an operation is allowed in the current safety mode using semantic impact policy.
- * Unknown modes fail closed.
- */
-export function isOperationAllowed(mode: SafetyMode | string, policy: OperationPolicy): boolean {
-  switch (mode) {
-    case SafetyMode.READ_ONLY:
-      return policy.impact === 'read';
-    case SafetyMode.WRITE_NONDESTRUCTIVE:
-    case SafetyMode.WRITE_IDEMPOTENT:
-      return (
-        policy.impact === 'read' ||
-        policy.impact === 'write-nondestructive' ||
-        policy.impact === 'external-side-effect'
-      );
-    case SafetyMode.WRITE_DESTRUCTIVE:
-      return true;
-    default:
-      return false;
-  }
-}
-
-/**
  * Resolves safety mode from environment variable.
  * Accepts `write-idempotent` as a deprecated alias for `write-nondestructive`.
  */
@@ -173,15 +135,6 @@ export function getAllowedProjectUuidsFromEnv(): string[] {
     .split(',')
     .map((s) => s.trim())
     .filter(Boolean);
-}
-
-/**
- * Returns true if a single projectUuid is permitted by the allowlist.
- * An empty allowlist means all projects are allowed.
- */
-export function isProjectAllowed(allowedUuids: readonly string[], projectUuid: string): boolean {
-  if (allowedUuids.length === 0) return true;
-  return allowedUuids.includes(projectUuid);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Remove unused `greet`, descriptor-driven `validateArguments`, and unused safety helpers (`isOperationAllowed`, `isProjectAllowed`, etc.) from `@lightdash-tools/common`
- Remove deprecated `createAxiosInstance`, duplicate `ApiResponse*` types, and the public `unwrapApiSuccessResults` barrel export from `@lightdash-tools/client`
- Keep production paths (`validateResourceIdsInObject`, `isAllowed`, v1/v2 axios factories)

## Test plan
- [ ] `pnpm build`
- [ ] `pnpm exec vitest run packages/common packages/client`
- [ ] `pnpm knip`
- [ ] Confirm no external consumers relied on removed exports


Made with [Cursor](https://cursor.com)