### PR TITLE
refactor(cli,mcp): reuse file-input and shared readEnv

### DIFF
--- a/packages/cli/src/commands/charts.ts
+++ b/packages/cli/src/commands/charts.ts
@@ -2,49 +2,14 @@
  * Charts (v1) command implementation.
  */
 
-import { readFileSync } from 'fs';
-
 import { READ_ONLY_DEFAULT, WRITE_IDEMPOTENT } from '@lightdash-tools/common';
 
 import { getClient } from '../utils/client';
+import { readParsedInput } from '../utils/file-input';
 import { wrapAction } from '../utils/safety';
 
 import type { UpsertChartAsCodeBody } from '@lightdash-tools/common';
 import type { Command } from 'commander';
-
-/**
- * Reads JSON from stdin or a file (for chart-as-code upsert body).
- */
-async function readChartJsonInput(filePath?: string): Promise<UpsertChartAsCodeBody> {
-  if (filePath) {
-    const content = readFileSync(filePath, 'utf-8');
-    return JSON.parse(content) as UpsertChartAsCodeBody;
-  }
-  return new Promise((resolve, reject) => {
-    if (process.stdin.isTTY) {
-      reject(new Error('No input provided. Use --file <path> or pipe JSON to stdin.'));
-      return;
-    }
-    const chunks: Buffer[] = [];
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', (chunk) => {
-      chunks.push(Buffer.from(chunk));
-    });
-    process.stdin.on('end', () => {
-      try {
-        const input = Buffer.concat(chunks).toString('utf-8');
-        resolve(JSON.parse(input) as UpsertChartAsCodeBody);
-      } catch (err) {
-        reject(
-          new Error(`Failed to parse JSON: ${err instanceof Error ? err.message : String(err)}`),
-        );
-      }
-    });
-    process.stdin.on('error', (err) => {
-      reject(err);
-    });
-  });
-}
 
 /**
  * Registers the projects charts subcommands under the existing projects command.
@@ -123,7 +88,7 @@ export function registerChartsCommand(program: Command): void {
         WRITE_IDEMPOTENT,
         async (projectUuid: string, slug: string, options: { file?: string }) => {
           try {
-            const body = await readChartJsonInput(options.file);
+            const body = (await readParsedInput({ file: options.file })) as UpsertChartAsCodeBody;
             const client = getClient();
             const result = await client.v1.charts.upsertChartAsCode(projectUuid, slug, body);
             console.log(JSON.stringify(result, null, 2));

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -2,51 +2,14 @@
  * Query command implementation.
  */
 
-import { readFileSync } from 'fs';
-
 import { READ_ONLY_DEFAULT } from '@lightdash-tools/common';
 
 import { getClient } from '../utils/client';
+import { readParsedInput } from '../utils/file-input';
 import { wrapAction } from '../utils/safety';
 
 import type { CompileQueryRequest } from '@lightdash-tools/common';
 import type { Command } from 'commander';
-
-/**
- * Reads JSON from stdin or a file.
- */
-async function readJsonInput(filePath?: string): Promise<unknown> {
-  if (filePath) {
-    const content = readFileSync(filePath, 'utf-8');
-    return JSON.parse(content);
-  }
-  // Read from stdin
-  return new Promise((resolve, reject) => {
-    // Check if stdin is a TTY (interactive terminal)
-    if (process.stdin.isTTY) {
-      reject(new Error('No input provided. Use --file <path> or pipe JSON to stdin.'));
-      return;
-    }
-    const chunks: Buffer[] = [];
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', (chunk) => {
-      chunks.push(Buffer.from(chunk));
-    });
-    process.stdin.on('end', () => {
-      try {
-        const input = Buffer.concat(chunks).toString('utf-8');
-        resolve(JSON.parse(input));
-      } catch (err) {
-        reject(
-          new Error(`Failed to parse JSON: ${err instanceof Error ? err.message : String(err)}`),
-        );
-      }
-    });
-    process.stdin.on('error', (err) => {
-      reject(err);
-    });
-  });
-}
 
 /**
  * Registers the query command and its subcommands.
@@ -65,17 +28,7 @@ export function registerQueryCommand(program: Command): void {
         READ_ONLY_DEFAULT,
         async (projectUuid: string, exploreId: string, options: { file?: string }) => {
           try {
-            if (!projectUuid) {
-              console.error('Error: projectUuid is required');
-              process.exit(1);
-            }
-            if (!exploreId) {
-              console.error('Error: exploreId is required');
-              process.exit(1);
-            }
-
-            // Read JSON input
-            const body = (await readJsonInput(options.file)) as CompileQueryRequest;
+            const body = (await readParsedInput({ file: options.file })) as CompileQueryRequest;
 
             const client = getClient();
             const result = await client.v1.query.compileQuery(projectUuid, exploreId, body);

--- a/packages/mcp/src/config/load-mcp-config.ts
+++ b/packages/mcp/src/config/load-mcp-config.ts
@@ -38,6 +38,7 @@ import {
 import { normalizeLightdashUrl, normalizePublicUrl, isLocalHttpOrigin } from './normalize-url.js';
 import { assertObsoleteEnvRejected } from './obsolete-env.js';
 import { requirePublicUrl } from './public-url.js';
+import { readEnv } from './read-env.js';
 
 import type { McpAuthMode } from '../auth/auth-mode.js';
 
@@ -49,13 +50,6 @@ function warnDeprecatedAlias(oldName: string, newName: string): void {
   if (warnedAliases.has(oldName)) return;
   warnedAliases.add(oldName);
   console.warn(`Warning: ${oldName} is deprecated. Use ${newName}.`);
-}
-
-function readEnv(name: string, env: NodeJS.ProcessEnv): string | undefined {
-  // eslint-disable-next-line security/detect-object-injection -- env var names are fixed constants in this module
-  const value = env[name];
-  if (value === undefined || value === '') return undefined;
-  return value;
 }
 
 function parsePositiveIntegerEnv(name: string, value: string): number {

--- a/packages/mcp/src/config/obsolete-env.ts
+++ b/packages/mcp/src/config/obsolete-env.ts
@@ -18,6 +18,7 @@ import {
   ENV_LIGHTDASH_TOOLS_OAUTH_CLIENT_ID,
   ENV_LIGHTDASH_TOOLS_OAUTH_CLIENT_SECRET,
 } from './env.js';
+import { readEnv } from './read-env.js';
 
 const OBSOLETE_ENV_VARS = [
   ENV_LIGHTDASH_TOOLS_MCP_AUTH_MODE,
@@ -31,13 +32,6 @@ const OBSOLETE_ENV_VARS = [
   ENV_LIGHTDASH_TOOLS_MCP_STORE,
   ENV_LIGHTDASH_TOOLS_MCP_REDIS_URL,
 ] as const;
-
-function readEnv(name: string, env: NodeJS.ProcessEnv): string | undefined {
-  // eslint-disable-next-line security/detect-object-injection -- env var names are fixed constants
-  const value = env[name];
-  if (value === undefined || value === '') return undefined;
-  return value;
-}
 
 /** Fail closed when operators still set removed MCP env vars. */
 export function assertObsoleteEnvRejected(env: NodeJS.ProcessEnv = process.env): void {

--- a/packages/mcp/src/config/read-env.ts
+++ b/packages/mcp/src/config/read-env.ts
@@ -1,0 +1,10 @@
+/**
+ * Read a process env value, treating empty string as unset.
+ */
+
+export function readEnv(name: string, env: NodeJS.ProcessEnv): string | undefined {
+  // eslint-disable-next-line security/detect-object-injection -- env var names are fixed constants at call sites
+  const value = env[name];
+  if (value === undefined || value === '') return undefined;
+  return value;
+}


### PR DESCRIPTION
## Summary
- Replace duplicate JSON stdin/file readers in CLI `query` and `charts` with existing `readParsedInput`
- Extract shared MCP `readEnv` used by `load-mcp-config` and `obsolete-env`
- Independent of the dead-exports PR

## Test plan
- [ ] `pnpm exec vitest run packages/cli packages/mcp/src/config`
- [ ] Smoke: `lightdash-tools query compile … --file …` and charts upsert from `--file`/stdin
- [ ] MCP config still rejects obsolete env vars


Made with [Cursor](https://cursor.com)