### PR TITLE
chore(knip): drop axios ignore and split type-barrel ignores

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,7 @@ Additional specialized skills are documented in `CLAUDE.md`.
 
 ## Common Gotchas
 
-- Use `pnpm` only (not npm/yarn). Enable Corepack if `pnpm` is missing.
+- Use `pnpm` only (not npm/yarn). Enable Corepack if `pnpm` is missing; run `corepack enable` before `pnpm verify:*`/other scripts that shell out to `pnpm`, because `corepack pnpm <cmd>` alone does not provide the `pnpm` shim for nested calls.
 - Trunk: `@trunkio/launcher` + `pnpm trunk:install`; restricted network → `pnpm lint:eslint` / `format:eslint` / `format:prettier`.
 - pnpm v11: `overrides` live in `pnpm-workspace.yaml`; keep lockfile committed; `packageManager` is `pnpm@11.5.3`.
 - Build before ESLint (`dist/` resolves); prefer root `pnpm exec vitest run <files>` over per-package `test:fast`.

--- a/knip.json
+++ b/knip.json
@@ -3,7 +3,7 @@
   "ignoreDependencies": [],
   "ignoreExportsUsedInFile": true,
   "ignoreIssues": {
-    "packages/common/src/types/**": [
+    "packages/common/src/types/generated/openapi-types.ts": [
       "exports",
       "types",
       "nsExports",
@@ -11,7 +11,38 @@
       "enumMembers",
       "namespaceMembers"
     ],
-    "packages/client/src/http/axios-client.ts": ["exports"]
+    "packages/common/src/types/v1/**": [
+      "exports",
+      "types",
+      "nsExports",
+      "nsTypes",
+      "enumMembers",
+      "namespaceMembers"
+    ],
+    "packages/common/src/types/v2/**": [
+      "exports",
+      "types",
+      "nsExports",
+      "nsTypes",
+      "enumMembers",
+      "namespaceMembers"
+    ],
+    "packages/common/src/types/lightdash-api.ts": [
+      "exports",
+      "types",
+      "nsExports",
+      "nsTypes",
+      "enumMembers",
+      "namespaceMembers"
+    ],
+    "packages/common/src/types/index.ts": [
+      "exports",
+      "types",
+      "nsExports",
+      "nsTypes",
+      "enumMembers",
+      "namespaceMembers"
+    ]
   },
   "workspaces": {
     ".": {


### PR DESCRIPTION
## Summary
- Remove obsolete `axios-client.ts` knip ignore (depends on dead-export cleanup)
- Replace blanket `packages/common/src/types/**` ignore with explicit generated + curated barrel paths
- Stacked on `refactor/simplify-dead-exports` — merge that PR first (or retarget to `main` after it lands)

## Test plan
- [ ] `pnpm knip` passes on this branch
- [ ] `pnpm verify:quick` after dead-exports base is available


Made with [Cursor](https://cursor.com)