### PR TITLE
feat(mcp): add content-developer table-calculations playbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,7 @@ Additional specialized skills are documented in `CLAUDE.md`.
 - Stdio: `lightdash-mcp stdio --profile <id>` only — no default; `http` mounts all profiles.
 - Audit: `initAuditLog()` once at startup; unset `LIGHTDASH_TOOLS_AUDIT_LOG` → JSON audit on stderr (Cloud Run).
 - Stateless MCP HTTP (ADR-0019): no SessionStore/Redis; obsolete store/redis env fail closed; OAuth broker is in-memory (sticky `/oauth/*`).
-- Content-developer: do not edit proposed body after preview (hash mismatch ≠ TTL); see ADR-0014/0019.
+- Content-developer: do not edit proposed body after preview (hash mismatch ≠ TTL); see ADR-0014/0019. Table-calc `fieldId`s must come from `get_chart_as_code` — preview/confirm do not prove they exist.
 - OpenAPI lists are wrapped (`results.data.<key>`); pin in `config/lightdash-openapi-ref.txt` — never hand-edit generated types.
 - MCP tests are CJS under `tsc` — no `import.meta`; stdio smoke spawns `dist/bin.js` with an explicit profile arg.
 - Knip: keep type-barrel `ignoreIssues`; delete unused intermediate re-exports rather than broaden ignores.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ Use the `/improve-claude-config` skill to orchestrate deeper changes.
 
 ## Recent Learnings
 
+- [2026-08-06]: Pivot row share SQL is `row_total(${metric})` (aggregate), not invented `pivot_row_total` — that name does not exist; `pivot_*` are offset/index/row helpers only. Preview still accepts bad SQL helpers.
 - [2026-08-06]: Content-developer `preview_chart_changes` / `confirm_preview` accept invented `tableCalculations` template `fieldId`s; copy real IDs from `get_chart_as_code` (jaffle: `orders_sum_order_amount`, not playbook-illustrative names). Profile cannot execute queries to verify calc row values.
 - [2026-08-05]: MCP SDK v2 progress uses `ctx.mcpReq.notify({ method: 'notifications/progress', params })` with `mcpReq._meta.progressToken`; a top-level `sendNotification` on `ServerContext` does not exist and silently no-ops reporters that look for it.
 - [2026-08-04]: MCP mounts are profile-owned `ToolModule` imports (ADR-0022). Export `defineTool` / `defineToolVariant` beside handlers; profiles import those modules; `registry.ts` is denylist + `registerTools` only — not a second catalog.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ Use the `/improve-claude-config` skill to orchestrate deeper changes.
 
 ## Recent Learnings
 
+- [2026-08-06]: Content-developer `preview_chart_changes` / `confirm_preview` accept invented `tableCalculations` template `fieldId`s; copy real IDs from `get_chart_as_code` (jaffle: `orders_sum_order_amount`, not playbook-illustrative names). Profile cannot execute queries to verify calc row values.
 - [2026-08-05]: MCP SDK v2 progress uses `ctx.mcpReq.notify({ method: 'notifications/progress', params })` with `mcpReq._meta.progressToken`; a top-level `sendNotification` on `ServerContext` does not exist and silently no-ops reporters that look for it.
 - [2026-08-04]: MCP mounts are profile-owned `ToolModule` imports (ADR-0022). Export `defineTool` / `defineToolVariant` beside handlers; profiles import those modules; `registry.ts` is denylist + `registerTools` only — not a second catalog.
 - [2026-08-04]: MCP stdio is transport-first — `lightdash-mcp stdio --profile <id>` (required); bare invoke fails closed; `http` for Streamable HTTP.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -79,17 +79,17 @@ Prefer `LIGHTDASH_TOOLS_*` env from the parent process. Avoid plaintext `.env` w
 
 ### Stdio
 
-| Required                             | Optional                                                                                      |
-| :----------------------------------- | :-------------------------------------------------------------------------------------------- |
-| `LIGHTDASH_URL`, `LIGHTDASH_API_KEY` | `LIGHTDASH_TOOLS_AUDIT_LOG` (file; else stderr JSON), `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS` |
+| Required                             | Optional                                                                                                            |
+| :----------------------------------- | :------------------------------------------------------------------------------------------------------------------ |
+| `LIGHTDASH_URL`, `LIGHTDASH_API_KEY` | `LIGHTDASH_TOOLS_AUDIT_LOG` (file; else stderr JSON), [`LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS`](#project-allowlist) |
 
 Do **not** set OAuth client secrets for stdio. MCP ignores CLI `SAFETY_MODE` / `DRY_RUN`.
 
 ### HTTP OAuth (primary)
 
-| Required                                                                                                                    | Common optional                                                   |
-| :-------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------- |
-| `LIGHTDASH_URL`, `LIGHTDASH_TOOLS_MCP_PUBLIC_URL`, `LIGHTDASH_TOOLS_OAUTH_CLIENT_ID`, `LIGHTDASH_TOOLS_OAUTH_CLIENT_SECRET` | port, `ALLOWED_ORIGINS`, `ALLOWED_PROJECT_UUIDS`, token cache TTL |
+| Required                                                                                                                    | Common optional                                                                                         |
+| :-------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------ |
+| `LIGHTDASH_URL`, `LIGHTDASH_TOOLS_MCP_PUBLIC_URL`, `LIGHTDASH_TOOLS_OAUTH_CLIENT_ID`, `LIGHTDASH_TOOLS_OAUTH_CLIENT_SECRET` | port, `ALLOWED_ORIGINS`, [`LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS`](#project-allowlist), token cache TTL |
 
 On Cloud Run / hosted HTTP, leave `LIGHTDASH_TOOLS_AUDIT_LOG` unset — tool audits are stderr JSON (`channel: "audit"`) → Cloud Logging. See [cloud-run.md](../../docs/operators/cloud-run.md).
 
@@ -109,6 +109,34 @@ Governance soft-delete needs client form elicitation; missing capability → `EL
 | :--------- | :----------------------------------------------------- |
 | Shared-key | `LIGHTDASH_API_KEY` + `LIGHTDASH_TOOLS_MCP_SHARED_KEY` |
 | Local none | `NODE_ENV=development` (not `production`)              |
+
+### Project allowlist
+
+Optional deployment ceiling shared with the CLI. Unset or empty → unrestricted beyond RBAC, HTTP pin, and tool `projectUuid`. Non-empty → hard allowlist for all profiles.
+
+**Format**
+
+- Comma-separated Lightdash project UUIDs (RFC 4122)
+- Whitespace around commas is ignored
+- No empty segments (double commas are rejected)
+- Invalid UUIDs fail at process startup
+- Input is case-insensitive; values are normalized to lowercase
+
+```bash
+# Single project
+export LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+
+# Multiple (spaces optional)
+export LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa, bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+```
+
+**Semantics**
+
+- Ceiling only — not a default project; tools still need `projectUuid` or an HTTP `X-Lightdash-Project` pin
+- When restricted, HTTP pin and every tool `projectUuid` must be in the set
+- `list_projects` returns only allowlisted projects; cross-project promote requires upstream targets in the set
+
+Architecture: [ADR-0008](../../docs/adr/0008-mcp-request-scope-and-hardening.md).
 
 Obsolete vars (`AUTH_MODE`, `EXPERIMENTAL_*`, `DANGEROUSLY_*`, `INSECURE_DEV`, `MCP_STORE`, `MCP_REDIS_URL`, free-form `MCP_PATH`) are **rejected**. See [ADR-0019](../../docs/adr/0019-mcp-stateless-protocol-core-without-redis-ephemeral-store.md).
 
@@ -147,7 +175,7 @@ Unsaved Explore-style metric queries (`run_metric_query`) with explore discovery
 - **Off MCP:** irrecoverable admin deletes, permanent content purge, broad org mutations — use `@lightdash-tools/client` or the CLI ([ADR-0004](../../docs/adr/0004-agent-safe-exposure-mcp-cli-vs-client-only.md)).
 - **Writes:** only on `content-developer` (preview gate). Soft-delete / promote: only on `content-governance` (form elicitation).
 - **Redaction:** emails masked unless `includeEmail=true`; scheduler destinations redacted unless `revealDestinations=true`; warehouse/dbt connection secrets never on MCP ([ADR-0011](../../docs/adr/0011-mcp-tool-response-sensitivity-classes.md)).
-- **Project scope:** optional HTTP pin `X-Lightdash-Project`, else tool `projectUuid`; optional ceiling `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS`.
+- **Project scope:** optional HTTP pin `X-Lightdash-Project`, else tool `projectUuid`; optional ceiling [`LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS`](#project-allowlist).
 
 Profile tool allowlists are the capability surface — not CLI safety-mode.
 

--- a/packages/mcp/src/profiles/content-developer/v1/prompts.test.ts
+++ b/packages/mcp/src/profiles/content-developer/v1/prompts.test.ts
@@ -26,6 +26,7 @@ describe('content-developer prompts/playbook', () => {
     expect(md).toContain('encode');
     expect(md).toMatch(/xref/);
     expect(md).toContain('chart-types');
+    expect(md).toContain('table-calculations');
     expect(md).not.toMatch(/`create_space`/);
     expect(md).not.toMatch(/`update_space`/);
     const toolIds = listToolIds(getProfile('content-developer'));
@@ -184,6 +185,7 @@ describe('content-developer prompts/playbook', () => {
     const promptArgs: Array<{ name: string; messages: unknown }> = [];
     let publishText = '';
     let authorText = '';
+    let authorUris: Array<string | undefined> = [];
     let refactorText = '';
     const server = {
       registerPrompt: (
@@ -221,13 +223,16 @@ describe('content-developer prompts/playbook', () => {
             goal: 'kpi',
             dashboardSlug: 'my-dash',
           }).messages as Array<{
-            content: { type: string; text?: string };
+            content: { type: string; text?: string; resource?: { uri?: string } };
           }>;
           authorText = messages
             .filter((m) => m.content.type === 'text')
             .map((m) => m.content.text ?? '')
             .join('\n')
             .toLowerCase();
+          authorUris = messages
+            .filter((m) => m.content.type === 'resource')
+            .map((m) => m.content.resource?.uri);
         }
         if (name === 'refactor_dashboard') {
           const messages = handler({
@@ -291,6 +296,9 @@ describe('content-developer prompts/playbook', () => {
     expect(publishText).toMatch(/untiled|leftover/);
     expect(publishText).toContain('content-governance');
     expect(authorText).toContain('board insight');
+    expect(authorText).toContain('table-calculations');
+    expect(authorUris).toContain('lightdash://playbooks/content-developer/chart-types');
+    expect(authorUris).toContain('lightdash://playbooks/content-developer/table-calculations');
     expect(refactorText).toMatch(/approved spec|user request allows/);
     expect(refactorText).not.toMatch(/unless explicitly requested/);
   });

--- a/packages/mcp/src/profiles/content-developer/v1/prompts.ts
+++ b/packages/mcp/src/profiles/content-developer/v1/prompts.ts
@@ -32,6 +32,8 @@ const PROJECT_UUID_HINT = '(pass on every tool, or use HTTP pin — else PROJECT
 const TOPIC_DASHBOARDS = 'dashboards' as const satisfies ContentDeveloperPlaybookTopic;
 const TOPIC_DASHBOARD_DESIGN = 'dashboard-design' as const satisfies ContentDeveloperPlaybookTopic;
 const TOPIC_CHART_TYPES = 'chart-types' as const satisfies ContentDeveloperPlaybookTopic;
+const TOPIC_TABLE_CALCULATIONS =
+  'table-calculations' as const satisfies ContentDeveloperPlaybookTopic;
 const DASHBOARD_CHART_TOPIC_IDS = [
   TOPIC_DASHBOARDS,
   TOPIC_DASHBOARD_DESIGN,
@@ -164,10 +166,10 @@ Dashboard slug: ${dashboardSlug ?? '(omit only for intentional space-owned chart
 
 ${CONTENT_DEVELOPER_HARD_BANS}
 
-Follow core + chart-types (clone via get_chart_as_code; preview with top-level slug; keep customDimensions when needed; tile if dashboardSlug set).
+Follow core + chart-types + table-calculations (clone via get_chart_as_code; preview with top-level slug; keep customDimensions when needed; tile if dashboardSlug set).
 When dashboardSlug is set, the chart must serve a **board insight** from the approved Design Spec — do not invent a viz type for its own sake.
 Report UUID/slug from charts[0].data; note this profile cannot run_chart / prove UI render.`,
-        TOPIC_CHART_TYPES,
+        [TOPIC_CHART_TYPES, TOPIC_TABLE_CALCULATIONS],
       ),
   );
 

--- a/packages/mcp/src/profiles/content-developer/v1/resources/playbooks.ts
+++ b/packages/mcp/src/profiles/content-developer/v1/resources/playbooks.ts
@@ -7,7 +7,7 @@ import { defineProfilePlaybooks } from '../../../lib/playbook-resources.js';
 import type { McpServer } from '@modelcontextprotocol/server';
 
 export type ContentDeveloperPlaybookTopic =
-  'chart-types' | 'content-move' | 'dashboard-design' | 'dashboards';
+  'chart-types' | 'content-move' | 'dashboard-design' | 'dashboards' | 'table-calculations';
 
 const playbooks = defineProfilePlaybooks<ContentDeveloperPlaybookTopic>({
   profileId: 'content-developer',
@@ -30,7 +30,7 @@ Do not mutate the proposed payload after preview_* (description/name/SQL/metrics
 Do not treat validate_chart / validate_dashboard as a preview unlock — they are saved-UUID health checks only (validate_chart needs chartUuid).
 Do not reuse a draft previewToken after confirm; re-run preview if the resource drifts (PREVIEW_STALE).
 Do not use subagent-driven-development or multi-task writing-plans solely to click MCP preview/confirm/apply for lab boards (e.g. experiments) — after Design Spec approval, run Batch SOP inline in the same session.
-Do not reveal secrets, warehouse credentials, or hidden SQL.`,
+Do not reveal secrets, warehouse credentials, or saved SQL chart bodies.`,
   coreDescription: 'Hard bans, tools, project scope, preview gate, and apply pitfalls',
   topics: [
     {
@@ -51,6 +51,13 @@ Do not reveal secrets, warehouse credentials, or hidden SQL.`,
       title: 'Content-developer chart-types playbook',
       description: 'Insight-first viz pick; cartesian encode checklist; UI intent → as-code map',
       file: 'chart-types.md',
+    },
+    {
+      id: 'table-calculations',
+      title: 'Content-developer table-calculations playbook',
+      description:
+        'metricQuery.tableCalculations: template → formula → sql; PoP, % of total, rank, windows',
+      file: 'table-calculations.md',
     },
     {
       id: 'content-move',

--- a/packages/mcp/src/profiles/content-developer/v1/resources/playbooks/chart-types.md
+++ b/packages/mcp/src/profiles/content-developer/v1/resources/playbooks/chart-types.md
@@ -4,6 +4,8 @@ URI: `lightdash://playbooks/content-developer/chart-types`
 
 Pick a viz type to **answer an insight question** from the Design Spec Objective. The table below is a **reference map**, not a build order — do not walk every row unless the user explicitly asked for multi-viz / all chart types. Prefer **clone** (`get_chart_as_code` / `duplicate_chart`) over inventing viz configs. Docs: [overview](https://docs.lightdash.com/references/chart-types/overview).
 
+When the insight needs period-over-period, % of total, rank, or running/rolling windows, append `metricQuery.tableCalculations` per `lightdash://playbooks/content-developer/table-calculations` (do not freestyle warehouse `OVER()` SQL).
+
 When the user **does** ask for all types: follow dashboards **Multi-viz batch SOP** (shell → ≤2 concurrent chart creates → one tile update), split the board into a decision-oriented section plus a visualization-validation appendix (see `dashboards` / `dashboard-design`), and check every candidate type against the **semantic fit gate** below before adding it.
 
 ## Semantic fit gate

--- a/packages/mcp/src/profiles/content-developer/v1/resources/playbooks/core.md
+++ b/packages/mcp/src/profiles/content-developer/v1/resources/playbooks/core.md
@@ -28,7 +28,7 @@ this profile does **not** execute queries, compile explores, create spaces, or p
 - Do not reuse a **draft** token after confirm (confirm returns a **new** validated token) or after payload/baseline drift (`PREVIEW_STALE`).
 - Do not unlock with a different resource's preview — `resourceKind` / `resourceKey` must match the preview exactly.
 - Do not treat `validate_chart` / `validate_dashboard` as unlock — saved-UUID health checks only (not UI-render proof).
-- Do not reveal secrets, warehouse credentials, or hidden SQL.
+- Do not reveal secrets, warehouse credentials, or saved SQL **chart** bodies.
 
 ## Default budgets (override when the user expands scope)
 
@@ -46,21 +46,21 @@ Record when a budget stopped you. User-requested “one of every chart type” o
 
 ## Allowed tools (`lightdash_*`)
 
-| Tool                                                                                             | Use for                                                                                          |
-| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
-| `get_project`                                                                                    | Resolve project; read `developerCapabilities` (mutate yes; **execute charts/tiles = false**)     |
-| `search_content`                                                                                 | Find charts/dashboards; prefer short tokens, not marketing phrases                               |
-| `list_spaces` / `get_space`                                                                      | Existing spaces; pick `spaceUuid` / `spaceSlug`                                                  |
-| `get_dashboard` / `get_chart`                                                                    | Metadata. `get_chart` arg is **`chartUuidOrSlug`** (not `chartUuid`). Tiles often omit `x/y/w/h` |
-| `get_chart_as_code`                                                                              | **Clone** upsert-shaped `chartConfig` + `metricQuery` before create/update                       |
-| `preview_chart_changes` / `preview_dashboard_changes` / `preview_content_move`                   | Mint draft `previewToken` + `resourceKey`                                                        |
-| `confirm_preview`                                                                                | Unlock; returns **new** validated token — always pass **`projectUuid`** without HTTP pin         |
-| `create_chart` / `update_chart` / `duplicate_chart`                                              | Semantic as-code writes (after confirm); set `dashboardSlug`                                     |
-| `create_dashboard` / `update_dashboard` / `duplicate_dashboard`                                  | Dashboard shell then tile updates                                                                |
-| `add_dashboard_tile` / `move_dashboard_tile` / `remove_dashboard_tile` / `resize_dashboard_tile` | Tile ops; each needs preview of the **full next tiles array**                                    |
-| `move_content`                                                                                   | Relocate into existing spaces                                                                    |
-| `validate_chart` / `validate_dashboard`                                                          | Optional post-apply health (`chartUuid` / dashboard UUID)                                        |
-| `compare_chart_versions` / `compare_dashboard_versions`                                          | Drift / refactor                                                                                 |
+| Tool                                                                                             | Use for                                                                                                                                                  |
+| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `get_project`                                                                                    | Resolve project; read `developerCapabilities` (mutate yes; **execute charts/tiles = false**)                                                             |
+| `search_content`                                                                                 | Find charts/dashboards; prefer short tokens, not marketing phrases                                                                                       |
+| `list_spaces` / `get_space`                                                                      | Existing spaces; pick `spaceUuid` / `spaceSlug`                                                                                                          |
+| `get_dashboard` / `get_chart`                                                                    | Metadata (+ query fields when included). `get_chart` is inspect-only — no `chartConfig`; use `get_chart_as_code` to clone. Arg is **`chartUuidOrSlug`**. |
+| `get_chart_as_code`                                                                              | **Clone** upsert-shaped `chartConfig` + `metricQuery` before create/update                                                                               |
+| `preview_chart_changes` / `preview_dashboard_changes` / `preview_content_move`                   | Mint draft `previewToken` + `resourceKey`                                                                                                                |
+| `confirm_preview`                                                                                | Unlock; returns **new** validated token — always pass **`projectUuid`** without HTTP pin                                                                 |
+| `create_chart` / `update_chart` / `duplicate_chart`                                              | Semantic as-code writes (after confirm); set `dashboardSlug`                                                                                             |
+| `create_dashboard` / `update_dashboard` / `duplicate_dashboard`                                  | Dashboard shell then tile updates                                                                                                                        |
+| `add_dashboard_tile` / `move_dashboard_tile` / `remove_dashboard_tile` / `resize_dashboard_tile` | Tile ops; each needs preview of the **full next tiles array**                                                                                            |
+| `move_content`                                                                                   | Relocate into existing spaces                                                                                                                            |
+| `validate_chart` / `validate_dashboard`                                                          | Optional post-apply health (`chartUuid` / dashboard UUID)                                                                                                |
+| `compare_chart_versions` / `compare_dashboard_versions`                                          | Drift / refactor                                                                                                                                         |
 
 ## Phase 0 — Resolve project
 
@@ -107,3 +107,4 @@ Record when a budget stopped you. User-requested “one of every chart type” o
 - Tile shape: `{ type: 'saved_chart', x, y, w, h, properties: { savedChartUuid, title? } }` — use the UUID from `create_chart` / `duplicate_chart` (36-column grid; half-width ≈ `w: 18`). Optional `chartSlug` is metadata only; do not omit `savedChartUuid`.
 - `create_chart` response: extract UUID from `charts[0].data.uuid` (not a bare chart object).
 - Viz shapes: `lightdash://playbooks/content-developer/chart-types`.
+- PoP / % of total / rank / running or rolling windows on `metricQuery.tableCalculations`: `lightdash://playbooks/content-developer/table-calculations`.

--- a/packages/mcp/src/profiles/content-developer/v1/resources/playbooks/dashboards.md
+++ b/packages/mcp/src/profiles/content-developer/v1/resources/playbooks/dashboards.md
@@ -41,7 +41,7 @@ Semantic as-code only. Prefer clone, not invent.
 1. Prefer **reuse** of an existing chart as a tile when it already fits.
 2. Else `search_content` / `get_space` → pick a **rendering** seed on the same `tableName` (same explore).
 3. `get_chart_as_code` (or `duplicate_chart`) → **keep `chartConfig` structure** (layout + series encode); edit only `name`, `slug`, and `metricQuery` fields that exist on the explore; set `dashboardSlug` = dashboard slug from step 1.
-4. Viz type / encode details: `lightdash://playbooks/content-developer/chart-types`.
+4. Viz type / encode details: `lightdash://playbooks/content-developer/chart-types`. PoP / % of total / rank / windows on `metricQuery.tableCalculations`: `lightdash://playbooks/content-developer/table-calculations`.
 
 Then:
 

--- a/packages/mcp/src/profiles/content-developer/v1/resources/playbooks/index.md
+++ b/packages/mcp/src/profiles/content-developer/v1/resources/playbooks/index.md
@@ -4,12 +4,13 @@ URI: `lightdash://playbooks/content-developer`
 
 Workflow-scoped playbooks (always load **core** plus one topic with a prompt):
 
-| Topic                                                        | URI                                                        |
-| ------------------------------------------------------------ | ---------------------------------------------------------- |
-| Core (gates & bans)                                          | `lightdash://playbooks/content-developer/core`             |
-| Dashboards & dashboard-owned charts                          | `lightdash://playbooks/content-developer/dashboards`       |
-| Dashboard design (Design Spec + layout / markdown / filters) | `lightdash://playbooks/content-developer/dashboard-design` |
-| Chart types (cartesian + pie/funnel/…)                       | `lightdash://playbooks/content-developer/chart-types`      |
-| Content move                                                 | `lightdash://playbooks/content-developer/content-move`     |
+| Topic                                                        | URI                                                          |
+| ------------------------------------------------------------ | ------------------------------------------------------------ |
+| Core (gates & bans)                                          | `lightdash://playbooks/content-developer/core`               |
+| Dashboards & dashboard-owned charts                          | `lightdash://playbooks/content-developer/dashboards`         |
+| Dashboard design (Design Spec + layout / markdown / filters) | `lightdash://playbooks/content-developer/dashboard-design`   |
+| Chart types (cartesian + pie/funnel/…)                       | `lightdash://playbooks/content-developer/chart-types`        |
+| Table calculations (template / formula / sql)                | `lightdash://playbooks/content-developer/table-calculations` |
+| Content move                                                 | `lightdash://playbooks/content-developer/content-move`       |
 
 **Authoring order:** clarify Objective → Design Spec → approve → dashboard shell → charts with `dashboardSlug` → tiles (+ optional filters; prefer one explore or `tileTargets` exclude by tile UUID). Always pass **`projectUuid`** on `confirm_preview` and apply when there is no HTTP pin. Clone via `get_chart_as_code`; never invent fieldIds or skinny `chartConfig` (cartesian series need `encode.xRef`/`yRef`). Multi-viz / all chart types only when the user explicitly asks (batch: shell → charts ≤2 parallel → one tile update). Cap concurrent writes at ≤2 on hosted tunnels. Spaces are Terraform / out-of-band (`list_spaces` / `get_space` only).

--- a/packages/mcp/src/profiles/content-developer/v1/resources/playbooks/table-calculations.md
+++ b/packages/mcp/src/profiles/content-developer/v1/resources/playbooks/table-calculations.md
@@ -15,23 +15,24 @@ Docs: [overview](https://docs.lightdash.com/guides/table-calculations) · [formu
 
 1. **`template`** — quick types + `window_function` (OpenAPI `TemplateTableCalculation`).
 2. **`formula`** — portable spreadsheet syntax starting with `=` ([formula docs](https://docs.lightdash.com/guides/formula-table-calculations)); column names match results headers.
-3. **`sql`** — only for `total()` / `row_total()` / `pivot_*`, or when formula cannot express it.
+3. **`sql`** — only for `total()` / `row_total()` / real `pivot_*` helpers (`pivot_offset`, `pivot_index`, `pivot_row`, …), or when formula cannot express it. Never invent names like `pivot_row_total`.
 
 Formula and SQL modes are **not** interconvertible — delete and recreate to switch ([formula FAQ](https://docs.lightdash.com/guides/formula-table-calculations)).
 
 ## Intent → shape
 
-| Intent                                   | Prefer                  | OpenAPI / expression                                                                                                                       |
-| ---------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| % change from previous                   | `template`              | `type: percent_change_from_previous` + `fieldId` + `orderBy`                                                                               |
-| % of previous value                      | `template`              | `type: percent_of_previous_value` + `fieldId` + `orderBy`                                                                                  |
-| % of column total                        | `template`              | `type: percent_of_column_total` + `fieldId`                                                                                                |
-| Rank in column                           | `template`              | `type: rank_in_column` + `fieldId`                                                                                                         |
-| Running total                            | `template`              | `type: running_total` + `fieldId`                                                                                                          |
-| Rolling / moving window                  | `template` or `formula` | `window_function` + `frame`, or `MOVING_AVG` / `MOVING_SUM`                                                                                |
-| Simple ratio / IF / date math            | `formula`               | e.g. `=orders_sum_order_amount / orders_num_unique_order_ids`                                                                              |
-| Grand % of total (correct metric re-agg) | `sql`                   | `${metric} / total(${metric})` ([aggregate](https://docs.lightdash.com/references/table-calculation-functions/aggregate-functions))        |
-| Pivot row share / cross-column           | `sql`                   | `row_total` / `pivot_*` **only when pivoted** ([pivot](https://docs.lightdash.com/references/table-calculation-functions/pivot-functions)) |
+| Intent                                   | Prefer                  | OpenAPI / expression                                                                                                                                                                 |
+| ---------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| % change from previous                   | `template`              | `type: percent_change_from_previous` + `fieldId` + `orderBy`                                                                                                                         |
+| % of previous value                      | `template`              | `type: percent_of_previous_value` + `fieldId` + `orderBy`                                                                                                                            |
+| % of column total                        | `template`              | `type: percent_of_column_total` + `fieldId`                                                                                                                                          |
+| Rank in column                           | `template`              | `type: rank_in_column` + `fieldId`                                                                                                                                                   |
+| Running total                            | `template`              | `type: running_total` + `fieldId`                                                                                                                                                    |
+| Rolling / moving window                  | `template` or `formula` | `window_function` + `frame`, or `MOVING_AVG` / `MOVING_SUM`                                                                                                                          |
+| Simple ratio / IF / date math            | `formula`               | e.g. `=orders_sum_order_amount / orders_num_unique_order_ids`                                                                                                                        |
+| Grand % of total (correct metric re-agg) | `sql`                   | `${metric} / total(${metric})` ([aggregate](https://docs.lightdash.com/references/table-calculation-functions/aggregate-functions))                                                  |
+| Pivot row share                          | `sql`                   | `${metric} / row_total(${metric})` ([aggregate](https://docs.lightdash.com/references/table-calculation-functions/aggregate-functions)) — **not** `pivot_row_total` (does not exist) |
+| Cross-column pivot access                | `sql`                   | `pivot_offset` / `pivot_index` / `pivot_row` / … **only when pivoted** ([pivot](https://docs.lightdash.com/references/table-calculation-functions/pivot-functions))                  |
 
 SQL template guides: [percent change](https://docs.lightdash.com/guides/table-calculations/table-calculation-sql-templates/percent-change-from-previous), [percent of previous](https://docs.lightdash.com/guides/table-calculations/table-calculation-sql-templates/percent-of-previous-value), [percent of column](https://docs.lightdash.com/guides/table-calculations/table-calculation-sql-templates/percent-of-total-column), [percent of group/pivot](https://docs.lightdash.com/guides/table-calculations/table-calculation-sql-templates/percent-of-group-pivot-total), [rank](https://docs.lightdash.com/guides/table-calculations/table-calculation-sql-templates/rank-in-column), [running total](https://docs.lightdash.com/guides/table-calculations/table-calculation-sql-templates/running-total), [rolling window](https://docs.lightdash.com/guides/table-calculations/table-calculation-sql-templates/rolling-window).
 
@@ -86,6 +87,19 @@ Field IDs are **illustrative** — copy real `fieldId`s from the explore / seed.
 }
 ```
 
+### SQL (percent of pivot row — requires `pivotConfig`)
+
+```json
+{
+  "name": "amount_pct_of_pivot_row",
+  "displayName": "% of pivot row total",
+  "type": "number",
+  "format": { "type": "percent" },
+  "totalMode": "formula",
+  "sql": "${orders.sum_order_amount} / row_total(${orders.sum_order_amount})"
+}
+```
+
 ## Authoring SOP
 
 1. Clone via `get_chart_as_code` (or `duplicate_chart`) — that returns upsert-shaped `chartConfig` + `metricQuery`. Append to `metricQuery.tableCalculations` (never omit the array — OpenAPI requires it). Use `get_chart` only to inspect existing calc expressions; it does **not** return `chartConfig`.
@@ -98,6 +112,7 @@ Field IDs are **illustrative** — copy real `fieldId`s from the explore / seed.
 
 - Do not invent `fieldId`s or results-header column names. Copy them from `get_chart_as_code` / explore seeds — playbook skeletons are examples only.
 - `preview_chart_changes` / `confirm_preview` do **not** prove template `fieldId`s or formula headers exist; inventing IDs can still preview-validate and only fail at query time.
+- Do not invent SQL helpers — use `total()` / `row_total()` ([aggregate](https://docs.lightdash.com/references/table-calculation-functions/aggregate-functions)) or documented `pivot_*` ([pivot](https://docs.lightdash.com/references/table-calculation-functions/pivot-functions)). There is no `pivot_row_total`.
 - Do not convert formula ↔ sql in place — recreate the calc.
 - Do not use `pivot_*` / `row_total` without a pivoted dimension (`pivotConfig.columns`).
 - Do not author SQL **charts** or open data-analyst / raw SQL execution to “fix” a table calc on this profile.

--- a/packages/mcp/src/profiles/content-developer/v1/resources/playbooks/table-calculations.md
+++ b/packages/mcp/src/profiles/content-developer/v1/resources/playbooks/table-calculations.md
@@ -29,7 +29,7 @@ Formula and SQL modes are **not** interconvertible — delete and recreate to sw
 | Rank in column                           | `template`              | `type: rank_in_column` + `fieldId`                                                                                                         |
 | Running total                            | `template`              | `type: running_total` + `fieldId`                                                                                                          |
 | Rolling / moving window                  | `template` or `formula` | `window_function` + `frame`, or `MOVING_AVG` / `MOVING_SUM`                                                                                |
-| Simple ratio / IF / date math            | `formula`               | e.g. `=orders_revenue / SUM(orders_revenue)`                                                                                               |
+| Simple ratio / IF / date math            | `formula`               | e.g. `=orders_sum_order_amount / orders_num_unique_order_ids`                                                                              |
 | Grand % of total (correct metric re-agg) | `sql`                   | `${metric} / total(${metric})` ([aggregate](https://docs.lightdash.com/references/table-calculation-functions/aggregate-functions))        |
 | Pivot row share / cross-column           | `sql`                   | `row_total` / `pivot_*` **only when pivoted** ([pivot](https://docs.lightdash.com/references/table-calculation-functions/pivot-functions)) |
 
@@ -48,15 +48,15 @@ Field IDs are **illustrative** — copy real `fieldId`s from the explore / seed.
 
 ```json
 {
-  "name": "revenue_pct_change",
+  "name": "amount_pct_change",
   "displayName": "% change vs previous",
   "type": "number",
   "format": { "type": "percent" },
   "totalMode": "sum_of_rows",
   "template": {
     "type": "percent_change_from_previous",
-    "fieldId": "orders_total_order_amount",
-    "orderBy": [{ "fieldId": "orders_order_date_week", "order": "asc" }]
+    "fieldId": "orders_sum_order_amount",
+    "orderBy": [{ "fieldId": "orders_order_date_month", "order": "asc" }]
   }
 }
 ```
@@ -69,7 +69,7 @@ Field IDs are **illustrative** — copy real `fieldId`s from the explore / seed.
   "displayName": "Average order value",
   "type": "number",
   "totalMode": "formula",
-  "formula": "=orders_total_order_amount / orders_order_count"
+  "formula": "=orders_sum_order_amount / orders_num_unique_order_ids"
 }
 ```
 
@@ -77,12 +77,12 @@ Field IDs are **illustrative** — copy real `fieldId`s from the explore / seed.
 
 ```json
 {
-  "name": "revenue_pct_of_total",
+  "name": "amount_pct_of_total",
   "displayName": "% of total",
   "type": "number",
   "format": { "type": "percent" },
   "totalMode": "formula",
-  "sql": "${orders.total_order_amount} / total(${orders.total_order_amount})"
+  "sql": "${orders.sum_order_amount} / total(${orders.sum_order_amount})"
 }
 ```
 
@@ -96,8 +96,9 @@ Field IDs are **illustrative** — copy real `fieldId`s from the explore / seed.
 
 ## Hard bans
 
-- Do not invent `fieldId`s or results-header column names.
+- Do not invent `fieldId`s or results-header column names. Copy them from `get_chart_as_code` / explore seeds — playbook skeletons are examples only.
+- `preview_chart_changes` / `confirm_preview` do **not** prove template `fieldId`s or formula headers exist; inventing IDs can still preview-validate and only fail at query time.
 - Do not convert formula ↔ sql in place — recreate the calc.
-- Do not use `pivot_*` / `row_total` without a pivoted dimension.
+- Do not use `pivot_*` / `row_total` without a pivoted dimension (`pivotConfig.columns`).
 - Do not author SQL **charts** or open data-analyst / raw SQL execution to “fix” a table calc on this profile.
 - Do not freestyle warehouse-specific `OVER()` SQL when a `template` or `formula` covers the intent.

--- a/packages/mcp/src/profiles/content-developer/v1/resources/playbooks/table-calculations.md
+++ b/packages/mcp/src/profiles/content-developer/v1/resources/playbooks/table-calculations.md
@@ -1,0 +1,103 @@
+# Content-developer — table calculations
+
+URI: `lightdash://playbooks/content-developer/table-calculations`
+
+Add chart-local metrics on top of explore dimensions/metrics via `metricQuery.tableCalculations`. Prefer clone (`get_chart_as_code`) then append calcs. This profile **cannot** run queries to verify row values.
+
+Docs: [overview](https://docs.lightdash.com/guides/table-calculations) · [formula](https://docs.lightdash.com/guides/formula-table-calculations) · [SQL templates](https://docs.lightdash.com/guides/table-calculations/sql-templates) · [as-code](https://docs.lightdash.com/guides/developer/dashboards-as-code) · [row](https://docs.lightdash.com/references/table-calculation-functions/row-functions) / [pivot](https://docs.lightdash.com/references/table-calculation-functions/pivot-functions) / [aggregate](https://docs.lightdash.com/references/table-calculation-functions/aggregate-functions) functions.
+
+## When to use
+
+- Chart-specific PoP, % of total, rank, running total, rolling window, pivot share.
+- If the same calc is reused across many boards → put it in **dbt** / the semantic layer instead ([overview](https://docs.lightdash.com/guides/table-calculations)).
+
+## Preference (playbook policy)
+
+1. **`template`** — quick types + `window_function` (OpenAPI `TemplateTableCalculation`).
+2. **`formula`** — portable spreadsheet syntax starting with `=` ([formula docs](https://docs.lightdash.com/guides/formula-table-calculations)); column names match results headers.
+3. **`sql`** — only for `total()` / `row_total()` / `pivot_*`, or when formula cannot express it.
+
+Formula and SQL modes are **not** interconvertible — delete and recreate to switch ([formula FAQ](https://docs.lightdash.com/guides/formula-table-calculations)).
+
+## Intent → shape
+
+| Intent                                   | Prefer                  | OpenAPI / expression                                                                                                                       |
+| ---------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| % change from previous                   | `template`              | `type: percent_change_from_previous` + `fieldId` + `orderBy`                                                                               |
+| % of previous value                      | `template`              | `type: percent_of_previous_value` + `fieldId` + `orderBy`                                                                                  |
+| % of column total                        | `template`              | `type: percent_of_column_total` + `fieldId`                                                                                                |
+| Rank in column                           | `template`              | `type: rank_in_column` + `fieldId`                                                                                                         |
+| Running total                            | `template`              | `type: running_total` + `fieldId`                                                                                                          |
+| Rolling / moving window                  | `template` or `formula` | `window_function` + `frame`, or `MOVING_AVG` / `MOVING_SUM`                                                                                |
+| Simple ratio / IF / date math            | `formula`               | e.g. `=orders_revenue / SUM(orders_revenue)`                                                                                               |
+| Grand % of total (correct metric re-agg) | `sql`                   | `${metric} / total(${metric})` ([aggregate](https://docs.lightdash.com/references/table-calculation-functions/aggregate-functions))        |
+| Pivot row share / cross-column           | `sql`                   | `row_total` / `pivot_*` **only when pivoted** ([pivot](https://docs.lightdash.com/references/table-calculation-functions/pivot-functions)) |
+
+SQL template guides: [percent change](https://docs.lightdash.com/guides/table-calculations/table-calculation-sql-templates/percent-change-from-previous), [percent of previous](https://docs.lightdash.com/guides/table-calculations/table-calculation-sql-templates/percent-of-previous-value), [percent of column](https://docs.lightdash.com/guides/table-calculations/table-calculation-sql-templates/percent-of-total-column), [percent of group/pivot](https://docs.lightdash.com/guides/table-calculations/table-calculation-sql-templates/percent-of-group-pivot-total), [rank](https://docs.lightdash.com/guides/table-calculations/table-calculation-sql-templates/rank-in-column), [running total](https://docs.lightdash.com/guides/table-calculations/table-calculation-sql-templates/running-total), [rolling window](https://docs.lightdash.com/guides/table-calculations/table-calculation-sql-templates/rolling-window).
+
+## Format and totals
+
+- Percent-style calcs: set `format: { type: 'percent' }` (and `type: 'number'` when needed).
+- `totalMode`: `formula` for ratios evaluated at total grain; `sum_of_rows` for windows / template windows; `none` when a total is meaningless ([totals](https://docs.lightdash.com/guides/table-calculations)).
+
+## JSON skeletons
+
+Field IDs are **illustrative** — copy real `fieldId`s from the explore / seed.
+
+### Template (percent change)
+
+```json
+{
+  "name": "revenue_pct_change",
+  "displayName": "% change vs previous",
+  "type": "number",
+  "format": { "type": "percent" },
+  "totalMode": "sum_of_rows",
+  "template": {
+    "type": "percent_change_from_previous",
+    "fieldId": "orders_total_order_amount",
+    "orderBy": [{ "fieldId": "orders_order_date_week", "order": "asc" }]
+  }
+}
+```
+
+### Formula (ratio)
+
+```json
+{
+  "name": "avg_order_value",
+  "displayName": "Average order value",
+  "type": "number",
+  "totalMode": "formula",
+  "formula": "=orders_total_order_amount / orders_order_count"
+}
+```
+
+### SQL (percent of grand total)
+
+```json
+{
+  "name": "revenue_pct_of_total",
+  "displayName": "% of total",
+  "type": "number",
+  "format": { "type": "percent" },
+  "totalMode": "formula",
+  "sql": "${orders.total_order_amount} / total(${orders.total_order_amount})"
+}
+```
+
+## Authoring SOP
+
+1. Clone via `get_chart_as_code` (or `duplicate_chart`) — that returns upsert-shaped `chartConfig` + `metricQuery`. Append to `metricQuery.tableCalculations` (never omit the array — OpenAPI requires it). Use `get_chart` only to inspect existing calc expressions; it does **not** return `chartConfig`.
+2. Align `metricQuery.sorts` with window `orderBy` / formula `ORDER BY`.
+3. If the calc is plotted, reference its `name` in viz encode / series like any metric fieldId.
+4. `preview_chart_changes` → `confirm_preview` → `create_chart` / `update_chart` with the **identical** proposed body.
+5. Do not claim verified numbers — this profile has no `run_chart` / warehouse execute.
+
+## Hard bans
+
+- Do not invent `fieldId`s or results-header column names.
+- Do not convert formula ↔ sql in place — recreate the calc.
+- Do not use `pivot_*` / `row_total` without a pivoted dimension.
+- Do not author SQL **charts** or open data-analyst / raw SQL execution to “fix” a table calc on this profile.
+- Do not freestyle warehouse-specific `OVER()` SQL when a `template` or `formula` covers the intent.

--- a/packages/mcp/src/profiles/content-reader/v1/resources/playbooks/core.md
+++ b/packages/mcp/src/profiles/content-reader/v1/resources/playbooks/core.md
@@ -41,17 +41,17 @@ Record budget / pagination / truncation stops in the answer.
 
 ## Allowed tools (`lightdash_*`)
 
-| Tool                                                 | Use for                                                  |
-| ---------------------------------------------------- | -------------------------------------------------------- |
-| `get_project`                                        | Resolve project; read `readerCapabilities` + pin context |
-| `search_content`                                     | Find charts/dashboards/spaces/data apps                  |
-| `list_spaces` / `get_space`                          | Space hierarchy + immediate content                      |
-| `get_dashboard` / `get_chart`                        | Structure / definition (SQL text hidden)                 |
-| `list_project_parameters` / `get_project_parameters` | Parameter defs / values                                  |
-| `explain_content`                                    | Compact metadata explanation                             |
-| `run_chart` / `run_dashboard_tile`                   | Bounded saved execution (numbers)                        |
-| `export_chart_image`                                 | PNG snapshot of a saved chart (vision); needs headless   |
-| `get_query_result` / `cancel_query`                  | Poll / cancel by `queryUuid`                             |
+| Tool                                                 | Use for                                                                                                                    |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `get_project`                                        | Resolve project; read `readerCapabilities` + pin context                                                                   |
+| `search_content`                                     | Find charts/dashboards/spaces/data apps                                                                                    |
+| `list_spaces` / `get_space`                          | Space hierarchy + immediate content                                                                                        |
+| `get_dashboard` / `get_chart`                        | Structure / definition (saved SQL **chart** bodies hidden; semantic `tableCalculations` may appear when query is included) |
+| `list_project_parameters` / `get_project_parameters` | Parameter defs / values                                                                                                    |
+| `explain_content`                                    | Compact metadata explanation                                                                                               |
+| `run_chart` / `run_dashboard_tile`                   | Bounded saved execution (numbers)                                                                                          |
+| `export_chart_image`                                 | PNG snapshot of a saved chart (vision); needs headless                                                                     |
+| `get_query_result` / `cancel_query`                  | Poll / cancel by `queryUuid`                                                                                               |
 
 ## Phase 0 — Resolve project
 

--- a/packages/mcp/src/profiles/content-reader/v1/resources/playbooks/explain-run.md
+++ b/packages/mcp/src/profiles/content-reader/v1/resources/playbooks/explain-run.md
@@ -14,7 +14,7 @@ URI: `lightdash://playbooks/content-reader/explain-run`
 | Signal                                                      | Action                                                                                         |
 | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | Search `source=sql`                                         | Do **not** call `run_chart`; explain metadata only; cite `CONTENT_NOT_EXECUTABLE` / capability |
-| `get_chart` → `chartType=sql` + warnings                    | Same — SQL text is hidden; execution disabled                                                  |
+| `get_chart` → `chartType=sql` + warnings                    | Same — saved SQL **chart** body hidden; execution disabled                                     |
 | Opaque API errors (e.g. “Saved query not found”) on SQL ids | Treat as non-executable; do not retry endlessly                                                |
 | `readerCapabilities.canExecuteSqlCharts=false`              | Hard stop for SQL execution                                                                    |
 

--- a/packages/mcp/src/tools/project/reader-content.test.ts
+++ b/packages/mcp/src/tools/project/reader-content.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for get_chart table-calculation pass-through.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { toReaderTableCalculation } from './reader-content.js';
+
+describe('toReaderTableCalculation', () => {
+  it('preserves formula table calculations', () => {
+    expect(
+      toReaderTableCalculation({
+        name: 'revenue_running_total',
+        displayName: 'Running total',
+        type: 'number',
+        totalMode: 'sum_of_rows',
+        formula: '=RUNNING_TOTAL(orders_total_order_amount)',
+        index: 0,
+      }),
+    ).toEqual({
+      name: 'revenue_running_total',
+      displayName: 'Running total',
+      type: 'number',
+      totalMode: 'sum_of_rows',
+      formula: '=RUNNING_TOTAL(orders_total_order_amount)',
+      index: 0,
+    });
+  });
+
+  it('preserves template table calculations', () => {
+    expect(
+      toReaderTableCalculation({
+        name: 'revenue_pct_change',
+        displayName: '% change vs previous',
+        type: 'number',
+        format: { type: 'percent' },
+        totalMode: 'sum_of_rows',
+        template: {
+          type: 'percent_change_from_previous',
+          fieldId: 'orders_total_order_amount',
+          orderBy: [{ fieldId: 'orders_order_date_week', order: 'asc' }],
+        },
+      }),
+    ).toEqual({
+      name: 'revenue_pct_change',
+      displayName: '% change vs previous',
+      type: 'number',
+      format: { type: 'percent' },
+      totalMode: 'sum_of_rows',
+      template: {
+        type: 'percent_change_from_previous',
+        fieldId: 'orders_total_order_amount',
+        orderBy: [{ fieldId: 'orders_order_date_week', order: 'asc' }],
+      },
+    });
+  });
+
+  it('preserves sql table calculations', () => {
+    expect(
+      toReaderTableCalculation({
+        name: 'pct_of_total',
+        displayName: '% of total',
+        sql: '${orders.total_order_amount} / total(${orders.total_order_amount})',
+        format: { type: 'percent' },
+      }),
+    ).toEqual({
+      name: 'pct_of_total',
+      displayName: '% of total',
+      format: { type: 'percent' },
+      sql: '${orders.total_order_amount} / total(${orders.total_order_amount})',
+    });
+  });
+});

--- a/packages/mcp/src/tools/project/reader-content.ts
+++ b/packages/mcp/src/tools/project/reader-content.ts
@@ -30,6 +30,29 @@ export function detectChartType(chart: Record<string, unknown>): 'semantic' | 's
   return 'unknown';
 }
 
+/** Pass through OpenAPI TableCalculation fields agents need to clone. */
+export function toReaderTableCalculation(tc: unknown): Record<string, unknown> {
+  const row = (tc ?? {}) as Record<string, unknown>;
+  const out: Record<string, unknown> = {
+    name: row.name,
+    displayName: row.displayName,
+  };
+  for (const key of [
+    'type',
+    'format',
+    'totalMode',
+    'index',
+    'formula',
+    'sql',
+    'template',
+  ] as const) {
+    if (row[key] !== undefined) {
+      out[key] = row[key];
+    }
+  }
+  return out;
+}
+
 /* eslint-disable-next-line sonarjs/cyclomatic-complexity -- chart shape mapping */
 function toReaderChart(chart: Record<string, unknown>, includeQuery: boolean) {
   const metricQuery = (chart.metricQuery ?? {}) as Record<string, unknown>;
@@ -41,10 +64,7 @@ function toReaderChart(chart: Record<string, unknown>, includeQuery: boolean) {
     ? (metricQuery.metrics as string[]).map((fieldId) => ({ fieldId }))
     : [];
   const tableCalculations = includeQuery
-    ? ((metricQuery.tableCalculations as unknown[]) ?? []).map((tc) => {
-        const row = tc as { name?: string; displayName?: string };
-        return { name: row.name, displayName: row.displayName };
-      })
+    ? ((metricQuery.tableCalculations as unknown[]) ?? []).map(toReaderTableCalculation)
     : undefined;
   return {
     uuid: chart.uuid,
@@ -239,7 +259,8 @@ export function registerGetChart(server: McpServer, contextProvider: McpContextP
     'get_chart',
     {
       title: 'Get chart',
-      description: 'Explain a saved chart definition (SQL text hidden)',
+      description:
+        'Explain a saved semantic chart definition (saved SQL chart bodies stay hidden; tableCalculations expressions included when includeQueryDefinition)',
       safety: METADATA_SAFETY,
       inputSchema: {
         projectUuid: projectUuidField().optional(),

--- a/packages/mcp/src/tools/project/reader-content.ts
+++ b/packages/mcp/src/tools/project/reader-content.ts
@@ -37,18 +37,26 @@ export function toReaderTableCalculation(tc: unknown): Record<string, unknown> {
     name: row.name,
     displayName: row.displayName,
   };
-  for (const key of [
-    'type',
-    'format',
-    'totalMode',
-    'index',
-    'formula',
-    'sql',
-    'template',
-  ] as const) {
-    if (row[key] !== undefined) {
-      out[key] = row[key];
-    }
+  if (row.type !== undefined) {
+    out.type = row.type;
+  }
+  if (row.format !== undefined) {
+    out.format = row.format;
+  }
+  if (row.totalMode !== undefined) {
+    out.totalMode = row.totalMode;
+  }
+  if (row.index !== undefined) {
+    out.index = row.index;
+  }
+  if (row.formula !== undefined) {
+    out.formula = row.formula;
+  }
+  if (row.sql !== undefined) {
+    out.sql = row.sql;
+  }
+  if (row.template !== undefined) {
+    out.template = row.template;
   }
   return out;
 }


### PR DESCRIPTION
Teach agents to author metricQuery.tableCalculations (template → formula → sql) and pass through calc expressions on get_chart while clarifying SQL chart body redaction.