### PR TITLE
feat(mcp): HTTP profile mount allowlist via LIGHTDASH_TOOLS_MCP_PROFILES

### DIFF
--- a/.changes/unreleased/feat-20260810-085735.yaml
+++ b/.changes/unreleased/feat-20260810-085735.yaml
@@ -1,0 +1,3 @@
+kind: feat
+body: 'MCP HTTP: optional LIGHTDASH_TOOLS_MCP_PROFILES allowlist to mount a subset of fixed profile paths.'
+time: 2026-08-10T08:57:35.884372+09:00

--- a/.changes/unreleased/fix-20260810-095306.yaml
+++ b/.changes/unreleased/fix-20260810-095306.yaml
@@ -1,0 +1,3 @@
+kind: fix
+body: Bump js-yaml to 4.3.1 and nanoid to 3.3.17 to remediate High SBOM findings (GHSA-5p4m-2wfm-xmqj, GHSA-2v37-7h3g-55p8).
+time: 2026-08-10T09:53:06.502972+09:00

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ Additional specialized skills are documented in `CLAUDE.md`.
 - MCP progress (SDK v2): emit via `ctx.mcpReq.notify` when `mcpReq._meta.progressToken` is set — there is no top-level `sendNotification` on `ServerContext` (ADR-0023).
 - Guardrails return `_lightdashBlocked`; upstream failures are coded `UPSTREAM_*` / `RATE_LIMITED`, not blocked markers.
 - Env: `LIGHTDASH_TOOLS_*`; shared allowlist `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS`; obsolete allowlist names fail closed. MCP HTTP listen: `LIGHTDASH_TOOLS_MCP_HTTP_PORT`, else platform `PORT` (Cloud Run), else `3100`. Launch via `npx`/`pnpm dlx`/`lightdash-mcp` — not `pnpm exec @lightdash-tools/mcp`.
-- Stdio: `lightdash-mcp stdio --profile <id>` only — no default; `http` mounts all profiles.
+- Stdio: `lightdash-mcp stdio --profile <id>` only — no default; `http` mounts all profiles unless `LIGHTDASH_TOOLS_MCP_PROFILES` is set (comma-separated ids; unset = all).
 - Audit: `initAuditLog()` once at startup; unset `LIGHTDASH_TOOLS_AUDIT_LOG` → JSON audit on stderr (Cloud Run).
 - Stateless MCP HTTP (ADR-0019): no SessionStore/Redis; obsolete store/redis env fail closed; OAuth broker is in-memory (sticky `/oauth/*`).
 - Content-developer: do not edit proposed body after preview (hash mismatch ≠ TTL); see ADR-0014/0019. Table-calc `fieldId`s must come from `get_chart_as_code` — preview/confirm do not prove they exist. Prefer cloned `generationType: periodOverPeriod` metrics over inventing PoP; do not set `verified` / `preserveVerification` unless the user asks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,7 +150,7 @@ Additional specialized skills are documented in `CLAUDE.md`.
 - Use `pnpm` only (not npm/yarn). Enable Corepack if `pnpm` is missing.
 - Corepack: if you invoke commands via `corepack pnpm ...`, run `corepack enable` before repo scripts that shell out to nested `pnpm` (for example `pnpm build`), or those nested calls fail with `pnpm: not found`.
 - Trunk: `@trunkio/launcher` + `pnpm trunk:install`; restricted network → `pnpm lint:eslint` / `format:eslint` / `format:prettier`.
-- pnpm v11: `overrides` live in `pnpm-workspace.yaml`; keep lockfile committed; `packageManager` is `pnpm@11.5.3`.
+- pnpm v11: `overrides` live in `pnpm-workspace.yaml`; keep lockfile committed; `packageManager` is `pnpm@11.5.3`. Use exact pins (or `~`) for security bumps — `>=x.y.z` can pull the next major.
 - Build before ESLint (`dist/` resolves); prefer root `pnpm exec vitest run <files>` over per-package `test:fast`.
 - Changie: `kindFormat: '### {{.Kind}}'`; fragments use kind keys (`feat`/`fix`), not Keep-a-Changelog labels.
 - `pnpm -r version` needs a clean tree — bump `packages/*/package.json` versions directly if dirty.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ Use the `/improve-claude-config` skill to orchestrate deeper changes.
 
 ## Recent Learnings
 
+- [2026-08-10]: HTTP `LIGHTDASH_TOOLS_MCP_PROFILES` is a mount allowlist (unset = all seven paths); stdio still requires `--profile` and ignores this env. Disabled paths and their RFC 9728 PRM 404.
 - [2026-08-07]: content-reader verified discovery is `list_verified_content` → `GET …/content-verification`; `search_content` / OpenAPI v2 content list has no `verifiedOnly` filter — prompt preference flags must call the dedicated tool.
 - [2026-08-07]: PoP on content-developer: prefer cloned metrics with `generationType: periodOverPeriod` from seeds; table calculations remain the fallback when seeds lack native PoP (Explorer “Add period comparison” UI is unavailable on MCP).
 - [2026-08-06]: Pivot row share SQL is `row_total(${metric})` (aggregate), not invented `pivot_row_total` — that name does not exist; `pivot_*` are offset/index/row helpers only. Preview still accepts bad SQL helpers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ Use the `/improve-claude-config` skill to orchestrate deeper changes.
 
 ## Recent Learnings
 
+- [2026-08-10]: pnpm `overrides` with `>=x.y.z` can jump majors (`js-yaml` 4→5, `nanoid` 3→6). Pin exact patched lines (4.3.1 / 3.3.17) for SBOM High CVEs.
 - [2026-08-10]: HTTP `LIGHTDASH_TOOLS_MCP_PROFILES` is a mount allowlist (unset = all seven paths); stdio still requires `--profile` and ignores this env. Disabled paths and their RFC 9728 PRM 404.
 - [2026-08-07]: content-reader verified discovery is `list_verified_content` → `GET …/content-verification`; `search_content` / OpenAPI v2 content list has no `verifiedOnly` filter — prompt preference flags must call the dedicated tool.
 - [2026-08-07]: PoP on content-developer: prefer cloned metrics with `generationType: periodOverPeriod` from seeds; table calculations remain the fallback when seeds lack native PoP (Explorer “Add period comparison” UI is unavailable on MCP).

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,6 +14,7 @@ services:
       NODE_ENV: development
       LIGHTDASH_TOOLS_MCP_HTTP_HOST: 0.0.0.0
       LIGHTDASH_TOOLS_MCP_HTTP_PORT: 8080
+      # Optional: LIGHTDASH_TOOLS_MCP_PROFILES=content-reader,content-developer
       # LIGHTDASH_TOOLS_MCP_PUBLIC_URL comes from .env (ephemeral *.trycloudflare.com host)
     healthcheck:
       test:

--- a/docs/adr/0006-mcp-profiles-shared-registry-fixed-paths.md
+++ b/docs/adr/0006-mcp-profiles-shared-registry-fixed-paths.md
@@ -6,7 +6,7 @@ Date: 2026-08-04
 
 Accepted
 
-Amended by profile boundary ADRs (0010, 0012, 0014, 0015, 0017, 0018, 0020). Mount membership superseded by profile-owned ToolModules ([ADR-0022](0022-mcp-profile-owned-toolmodules-replace-operations-catalog.md); former catalog/membership ADRs 0013/0021). Stdio has no default (2026-08-04): bare invoke fails closed; use `lightdash-mcp stdio --profile <id>` or `http`.
+Amended by profile boundary ADRs (0010, 0012, 0014, 0015, 0017, 0018, 0020) and [24. MCP HTTP profile mount allowlist via env](0024-mcp-http-profile-mount-allowlist-via-env.md). Mount membership superseded by profile-owned ToolModules ([ADR-0022](0022-mcp-profile-owned-toolmodules-replace-operations-catalog.md); former catalog/membership ADRs 0013/0021). Stdio has no default (2026-08-04): bare invoke fails closed; use `lightdash-mcp stdio --profile <id>` or `http`.
 
 ## Context
 

--- a/docs/adr/0024-mcp-http-profile-mount-allowlist-via-env.md
+++ b/docs/adr/0024-mcp-http-profile-mount-allowlist-via-env.md
@@ -1,0 +1,68 @@
+# 24. MCP HTTP profile mount allowlist via env
+
+Date: 2026-08-10
+
+## Status
+
+Accepted
+
+Amends [6. MCP profiles, shared registry, fixed paths](0006-mcp-profiles-shared-registry-fixed-paths.md)
+
+Related to [8. MCP request scope and hardening](0008-mcp-request-scope-and-hardening.md), [9. Cross-cutting conventions](0009-cross-cutting-conventions.md)
+
+## Context
+
+[ADR-0006](0006-mcp-profiles-shared-registry-fixed-paths.md) ships one MCP package with seven fixed HTTP paths. `lightdash-mcp http` mounted every path; clients chose a URL. That is still the right default, but a hosted process (Cloud Run, Compose) that only intends to serve reader or authoring personas still exposed guessable write/governance/analyst URLs to any valid OAuth bearer.
+
+Stdio already selects exactly one profile via `stdio --profile <id>`. An env default for stdio was rejected (0.13.0): MCP stdio authorization uses process credentials, not HTTP OAuth, and Cursor/Claude `args` already pass `--profile`.
+
+Free-form `LIGHTDASH_TOOLS_MCP_PATH` remains rejected. A process **tool** filter remains forbidden ([ADR-0008](0008-mcp-request-scope-and-hardening.md)). Operators still need a **mount** ceiling — which profile URLs exist — analogous to `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS` for projects.
+
+### Alternatives considered
+
+- **`http --profiles` CLI flag:** explicit, but Cloud Run is env-centric; operators would fork container `CMD` per environment.
+- **Edge/proxy path filter:** no product change, but easy to miss RFC 9728 PRM well-known routes; signing key would still be required.
+- **One Cloud Run service per profile:** strongest isolation, high ops cost for small teams.
+- **Stdio profile env:** recreates a footgun already removed; does not shrink hosted HTTP.
+
+### Trade-offs
+
+Unset/empty = all mounts (backward compatible) can surprise an operator who forgets the var. Fail-closed unknown ids and empty CSV segments limit that risk. Path-specific PRM for a disabled profile 404s so discovery does not advertise a dead resource.
+
+## Decision
+
+1. **HTTP-only allowlist** via `LIGHTDASH_TOOLS_MCP_PROFILES` (comma-separated known `ProfileId`s). Unset or empty → mount every shipped path (ADR-0006 default). Non-empty → only listed ids; unknown ids or empty segments fail at startup. No free-form paths. No aliases.
+2. **Stdio unchanged:** `lightdash-mcp stdio --profile <id>` only. This env is ignored on stdio.
+3. **Filter at the HTTP layer**, not the profile catalog. `getProfileByPath` / `tools` arrays stay complete. Disabled MCP paths and their path-specific PRM return the same 404 as unknown paths.
+4. **Root PRM** (`/.well-known/oauth-protected-resource`) uses `config.mcpPath`. When the allowlist omits `semantic-layer`, `mcpPath` is the first enabled id in `PROFILE_IDS` order so root metadata does not name a 404 resource.
+5. **`LIGHTDASH_TOOLS_MCP_REQUEST_STATE_KEY`** is required only when `content-developer` or `content-governance` is enabled (or when unrestricted).
+6. This is **not** a tool-registration filter. Capability inside an enabled profile remains that profile’s `tools` array ([ADR-0008](0008-mcp-request-scope-and-hardening.md) / [ADR-0022](0022-mcp-profile-owned-toolmodules-replace-operations-catalog.md)).
+
+```mermaid
+flowchart TD
+  startHttp[lightdash-mcp http]
+  parseEnv["parse LIGHTDASH_TOOLS_MCP_PROFILES"]
+  unsetAll[unset or empty: all shipped profiles]
+  allowlist[restricted: listed ids only]
+  signingKey{"content-developer or content-governance enabled?"}
+  requireKey[require REQUEST_STATE_KEY]
+  skipKey[skip REQUEST_STATE_KEY]
+  listen[listen: health plus OAuth plus enabled MCP paths]
+
+  startHttp --> parseEnv
+  parseEnv --> unsetAll
+  parseEnv --> allowlist
+  unsetAll --> signingKey
+  allowlist --> signingKey
+  signingKey -->|yes or unrestricted| requireKey
+  signingKey -->|no| skipKey
+  requireKey --> listen
+  skipKey --> listen
+```
+
+## Consequences
+
+- Operators can run a read-only or authoring Cloud Run revision without serving governance/analyst mounts or requiring a signing key.
+- Clients still connect by profile URL; a mis-aimed URL against a restricted process 404s instead of exposing another persona.
+- `http --help` continues to list all shipped profiles (offline inventory). Runtime enablement is env.
+- Adding a profile is still a new folder + fixed path; include the new id in the allowlist when restricted.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,5 +42,7 @@ Vocabulary: living product term is **profile**. The MCP protocol uses Host / Cli
 19. [MCP data-analyst profile ad-hoc metric-query boundary](0020-mcp-data-analyst-profile-ad-hoc-metric-query-boundary.md)
 20. [MCP mount membership via literal profile tables](0021-mcp-mount-membership-via-literal-profile-tables.md) (superseded by 0022)
 21. [MCP profile-owned ToolModules replace operations catalog](0022-mcp-profile-owned-toolmodules-replace-operations-catalog.md)
+22. [Request-scoped MCP operation notifications](0023-request-scoped-mcp-operation-notifications.md)
+23. [MCP HTTP profile mount allowlist via env](0024-mcp-http-profile-mount-allowlist-via-env.md)
 
 Number **16** is unused in the binding set (former pluggable Redis/ephemeral store; superseded by 0019).

--- a/docs/operators/cloud-run.md
+++ b/docs/operators/cloud-run.md
@@ -33,7 +33,7 @@ LIGHTDASH_TOOLS_OAUTH_CLIENT_ID=...   # from Secret Manager
 LIGHTDASH_TOOLS_OAUTH_CLIENT_SECRET=...
 ```
 
-Optional: `LIGHTDASH_TOOLS_MCP_ALLOWED_ORIGINS`, `LIGHTDASH_PROXY_AUTHORIZATION`, `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS` (comma-separated project UUID hard allowlist shared with CLI).
+Optional: `LIGHTDASH_TOOLS_MCP_ALLOWED_ORIGINS`, `LIGHTDASH_PROXY_AUTHORIZATION`, `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS` (comma-separated project UUID hard allowlist shared with CLI), `LIGHTDASH_TOOLS_MCP_PROFILES` (comma-separated profile ids; unset = all seven HTTP mounts).
 
 **Do not set `LIGHTDASH_TOOLS_AUDIT_LOG` on Cloud Run.** Tool audit entries are written as pure JSON NDJSON on **stderr** and are captured automatically by [Cloud Run logging](https://docs.cloud.google.com/run/docs/logging) into Cloud Logging (`jsonPayload`). A container file path is ephemeral and unsuitable as the primary audit sink. Use `LIGHTDASH_TOOLS_AUDIT_LOG` only for CLI/local file append.
 
@@ -87,7 +87,7 @@ Grant the sink writer identity permission on the destination bucket after create
 
 ### Governance companions (already in the product)
 
-- Profile URL + catalog membership (capability surface)
+- Profile URL + catalog membership (capability surface); optional `LIGHTDASH_TOOLS_MCP_PROFILES` mount ceiling
 - OAuth identity + Lightdash RBAC
 - `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS` process ceiling for shared services
 - Optional `X-Lightdash-Project` pin
@@ -118,3 +118,4 @@ gcloud run deploy lightdash-mcp \
 - [ ] `LIGHTDASH_TOOLS_AUDIT_LOG` unset (stderr → Cloud Logging)
 - [ ] Audit sink / retention configured if compliance requires >30 days
 - [ ] `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS` set when the service must not see the whole org
+- [ ] `LIGHTDASH_TOOLS_MCP_PROFILES` set when the service must not mount every persona

--- a/docs/operators/mcp-oauth.md
+++ b/docs/operators/mcp-oauth.md
@@ -80,21 +80,22 @@ Do **not** put `LIGHTDASH_TOOLS_OAUTH_CLIENT_*` in the client. See [cursor-claud
 
 ## Environment reference
 
-| Variable                              | Role                                                                    |
-| :------------------------------------ | :---------------------------------------------------------------------- |
-| `LIGHTDASH_URL`                       | Lightdash instance                                                      |
-| `LIGHTDASH_TOOLS_MCP_PUBLIC_URL`      | Public base URL (required for OAuth)                                    |
-| `LIGHTDASH_TOOLS_OAUTH_CLIENT_ID`     | Server-held Lightdash app client id                                     |
-| `LIGHTDASH_TOOLS_OAUTH_CLIENT_SECRET` | Server-held Lightdash app client secret                                 |
-| `LIGHTDASH_TOOLS_MCP_SHARED_KEY`      | Secondary shared-key gateway                                            |
-| `LIGHTDASH_API_KEY`                   | Stdio / shared-key / local none upstream PAT                            |
-| `LIGHTDASH_TOOLS_MCP_ALLOWED_ORIGINS` | Optional CORS allowlist                                                 |
-| `LIGHTDASH_TOOLS_AUDIT_LOG`           | Optional file path (CLI/local); unset → stderr JSON audit               |
-| `LIGHTDASH_TOOLS_MCP_HTTP_PORT`       | Default `3100`; if unset, platform `PORT` (e.g. Cloud Run), else `3100` |
+| Variable                              | Role                                                                     |
+| :------------------------------------ | :----------------------------------------------------------------------- |
+| `LIGHTDASH_URL`                       | Lightdash instance                                                       |
+| `LIGHTDASH_TOOLS_MCP_PUBLIC_URL`      | Public base URL (required for OAuth)                                     |
+| `LIGHTDASH_TOOLS_OAUTH_CLIENT_ID`     | Server-held Lightdash app client id                                      |
+| `LIGHTDASH_TOOLS_OAUTH_CLIENT_SECRET` | Server-held Lightdash app client secret                                  |
+| `LIGHTDASH_TOOLS_MCP_SHARED_KEY`      | Secondary shared-key gateway                                             |
+| `LIGHTDASH_API_KEY`                   | Stdio / shared-key / local none upstream PAT                             |
+| `LIGHTDASH_TOOLS_MCP_ALLOWED_ORIGINS` | Optional CORS allowlist                                                  |
+| `LIGHTDASH_TOOLS_AUDIT_LOG`           | Optional file path (CLI/local); unset → stderr JSON audit                |
+| `LIGHTDASH_TOOLS_MCP_HTTP_PORT`       | Default `3100`; if unset, platform `PORT` (e.g. Cloud Run), else `3100`  |
+| `LIGHTDASH_TOOLS_MCP_PROFILES`        | Optional HTTP mount allowlist (comma-separated profile ids; unset = all) |
 
 **Rejected at startup** (removed): `LIGHTDASH_TOOLS_MCP_AUTH_MODE`, `EXPERIMENTAL_IDENTITY_OAUTH`, `DANGEROUSLY_*`, `ALLOW_INSECURE_PUBLIC_URL`, `LIGHTDASH_TOOLS_MCP_INSECURE_DEV`, `LIGHTDASH_TOOLS_MCP_PATH`.
 
-CLI-only (ignored for MCP auth): `LIGHTDASH_TOOLS_SAFETY_MODE`, `DRY_RUN`. Shared with MCP: `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS`.
+CLI-only (ignored for MCP auth): `LIGHTDASH_TOOLS_SAFETY_MODE`, `DRY_RUN`. Shared with MCP: `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS`. HTTP-only: `LIGHTDASH_TOOLS_MCP_PROFILES` (stdio still uses `--profile`).
 
 ## Broker routes
 

--- a/docs/operators/secrets.md
+++ b/docs/operators/secrets.md
@@ -28,6 +28,7 @@ Set credentials via environment variables injected by your parent process. The t
 | `LIGHTDASH_PROXY_AUTHORIZATION`         | Proxy authorization header                                                                                                                                             |
 | `LIGHTDASH_TOOLS_SAFETY_MODE`           | CLI only — safety mode (`read-only`, `write-idempotent`, `write-destructive`)                                                                                          |
 | `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS` | CLI + MCP — comma-separated project UUIDs (ceiling; unset = unrestricted)                                                                                              |
+| `LIGHTDASH_TOOLS_MCP_PROFILES`          | MCP HTTP only — comma-separated profile ids to mount (unset = all). Stdio ignores this var.                                                                            |
 | `LIGHTDASH_TOOLS_DRY_RUN`               | CLI only — set to `1`, `true`, or `yes` to simulate mutating operations                                                                                                |
 | `LIGHTDASH_TOOLS_AUDIT_LOG`             | Optional file path for NDJSON audit append (CLI/local). Unset → stderr as pure JSON (`channel: "audit"`). On Cloud Run leave unset — see [cloud-run.md](cloud-run.md). |
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -55,7 +55,7 @@ Or install globally: `npm install -g @lightdash-tools/mcp`, then `lightdash-mcp 
 
 ### Streamable HTTP (remote)
 
-`http` mounts **every** fixed path from the profile table (no `--profile`); clients pick the path in the URL.
+`http` mounts every fixed path from the profile table by default (no `--profile`); clients pick the path in the URL. Optionally restrict mounts with `LIGHTDASH_TOOLS_MCP_PROFILES` (comma-separated profile ids; unset or empty → all).
 
 ```bash
 export LIGHTDASH_URL="https://app.lightdash.cloud"
@@ -87,9 +87,9 @@ Do **not** set OAuth client secrets for stdio. MCP ignores CLI `SAFETY_MODE` / `
 
 ### HTTP OAuth (primary)
 
-| Required                                                                                                                    | Common optional                                                                                         |
-| :-------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------ |
-| `LIGHTDASH_URL`, `LIGHTDASH_TOOLS_MCP_PUBLIC_URL`, `LIGHTDASH_TOOLS_OAUTH_CLIENT_ID`, `LIGHTDASH_TOOLS_OAUTH_CLIENT_SECRET` | port, `ALLOWED_ORIGINS`, [`LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS`](#project-allowlist), token cache TTL |
+| Required                                                                                                                    | Common optional                                                                                                                                               |
+| :-------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `LIGHTDASH_URL`, `LIGHTDASH_TOOLS_MCP_PUBLIC_URL`, `LIGHTDASH_TOOLS_OAUTH_CLIENT_ID`, `LIGHTDASH_TOOLS_OAUTH_CLIENT_SECRET` | port, `ALLOWED_ORIGINS`, [`LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS`](#project-allowlist), [`LIGHTDASH_TOOLS_MCP_PROFILES`](#profile-allowlist), token cache TTL |
 
 On Cloud Run / hosted HTTP, leave `LIGHTDASH_TOOLS_AUDIT_LOG` unset — tool audits are stderr JSON (`channel: "audit"`) → Cloud Logging. See [cloud-run.md](../../docs/operators/cloud-run.md).
 
@@ -97,9 +97,9 @@ Register Lightdash redirect URI: `{PUBLIC_URL}/oauth/callback`. Clients connect 
 
 ### Content-developer / content-governance signing
 
-| Required (non-test)                     | Notes                                                                                           |
-| :-------------------------------------- | :---------------------------------------------------------------------------------------------- |
-| `LIGHTDASH_TOOLS_MCP_REQUEST_STATE_KEY` | ≥32-byte secret for HMAC `previewToken` / `requestState` (fail closed if unset; not encryption) |
+| Required (non-test)                     | Notes                                                                                                                                                                                                     |
+| :-------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LIGHTDASH_TOOLS_MCP_REQUEST_STATE_KEY` | ≥32-byte secret for HMAC `previewToken` / `requestState` (fail closed if unset; not encryption). Required only when `content-developer` or `content-governance` is mounted (including unrestricted HTTP). |
 
 Governance soft-delete needs client form elicitation; missing capability → `ELICITATION_REQUIRED`.
 
@@ -109,6 +109,23 @@ Governance soft-delete needs client form elicitation; missing capability → `EL
 | :--------- | :----------------------------------------------------- |
 | Shared-key | `LIGHTDASH_API_KEY` + `LIGHTDASH_TOOLS_MCP_SHARED_KEY` |
 | Local none | `NODE_ENV=development` (not `production`)              |
+
+### Profile allowlist
+
+Optional HTTP-only mount ceiling. Unset or empty → all seven shipped profile paths. Non-empty → only listed profile ids are mounted; other paths (and their path-specific OAuth PRM) 404. Stdio ignores this variable (`stdio --profile` still required).
+
+**Format**
+
+- Comma-separated profile ids from the table above (`semantic-layer`, `content-reader`, …)
+- Whitespace around commas is ignored
+- No empty segments (double commas are rejected)
+- Unknown ids fail at process startup
+
+```bash
+export LIGHTDASH_TOOLS_MCP_PROFILES="content-reader,content-developer"
+```
+
+Architecture: [ADR-0024](../../docs/adr/0024-mcp-http-profile-mount-allowlist-via-env.md).
 
 ### Project allowlist
 

--- a/packages/mcp/src/auth/request-state-key.ts
+++ b/packages/mcp/src/auth/request-state-key.ts
@@ -10,7 +10,7 @@ const TEST_FALLBACK_KEY = 'lightdash-tools-dev-request-state-key!!';
 export const PREVIEW_TOKEN_KEY_PURPOSE = 'content-developer preview tokens are enabled';
 export const DESTRUCTIVE_REQUEST_STATE_KEY_PURPOSE =
   'content-governance destructive tools are enabled';
-/** HTTP ships all profiles; preview + destructive elicitation share one signing key. */
+/** Preview + destructive elicitation share one signing key when write profiles are mounted. */
 export const HTTP_SIGNED_STATE_KEY_PURPOSE =
   'HTTP MCP exposes content-developer preview tokens and content-governance destructive tools';
 

--- a/packages/mcp/src/auth/resource-server/oauth-protected-resource.ts
+++ b/packages/mcp/src/auth/resource-server/oauth-protected-resource.ts
@@ -1,3 +1,4 @@
+import { isProfileEnabled } from '../../config/enabled-profiles.js';
 import { OAUTH_AUTHORIZATION_SERVER_METADATA_PATH } from '../../config/env.js';
 import { normalizeMcpPath } from '../../config/normalize-url.js';
 import { requirePublicUrl } from '../../config/public-url.js';
@@ -56,16 +57,13 @@ export function getProtectedResourceMetadataPathUrl(
 
 /**
  * Resolves the profile MCP path for a PRM well-known request.
- * Root PRM maps to the default profile (`config.mcpPath`); path-specific PRM
- * is served only for shipped profile paths.
+ * Root PRM maps to `config.mcpPath`; path-specific PRM is served only for
+ * enabled shipped profile paths (ADR-0024).
  */
 export function resolveProtectedResourceMcpPath(
   path: string,
   config: McpHttpConfig,
 ): string | undefined {
-  if (!path.startsWith(OAUTH_PROTECTED_RESOURCE_ROOT)) {
-    return undefined;
-  }
   if (path === OAUTH_PROTECTED_RESOURCE_ROOT) {
     return config.mcpPath;
   }
@@ -74,7 +72,11 @@ export function resolveProtectedResourceMcpPath(
     return undefined;
   }
   const resourcePath = `/${path.slice(prefix.length)}`;
-  return getProfileByPath(resourcePath)?.path;
+  const profile = getProfileByPath(resourcePath);
+  if (!profile || !isProfileEnabled(config.enabledProfiles, profile.id)) {
+    return undefined;
+  }
+  return profile.path;
 }
 
 /** Well-known OAuth Authorization Server Metadata URL for an AS origin. */

--- a/packages/mcp/src/bin.ts
+++ b/packages/mcp/src/bin.ts
@@ -58,7 +58,7 @@ program
 
 program
   .command('http')
-  .description('Run MCP server over Streamable HTTP (all fixed profile paths)')
+  .description('Run MCP server over Streamable HTTP (fixed profile paths)')
   .addHelpText('after', formatProfilesHelp)
   .action(() => {
     runHttp();

--- a/packages/mcp/src/config/enabled-profiles.test.ts
+++ b/packages/mcp/src/config/enabled-profiles.test.ts
@@ -1,0 +1,96 @@
+import { PROFILE_IDS } from '@lightdash-tools/common';
+import { describe, expect, it } from 'vitest';
+
+import {
+  CONTENT_DEVELOPER_PROFILE_PATH,
+  CONTENT_READER_PROFILE_PATH,
+  getProfile,
+  SEMANTIC_LAYER_PROFILE_PATH,
+} from '../profiles/index.js';
+
+import {
+  UNRESTRICTED_ENABLED_PROFILES,
+  isProfileEnabled,
+  listEnabledProfilePaths,
+  parseEnabledProfiles,
+  requiresSignedStateKey,
+  resolveRootMcpPath,
+} from './enabled-profiles.js';
+import { ENV_LIGHTDASH_TOOLS_MCP_PROFILES } from './env.js';
+
+describe('parseEnabledProfiles', () => {
+  it('returns unrestricted when unset or empty', () => {
+    expect(parseEnabledProfiles(undefined)).toEqual(UNRESTRICTED_ENABLED_PROFILES);
+    expect(parseEnabledProfiles('')).toEqual(UNRESTRICTED_ENABLED_PROFILES);
+    expect(parseEnabledProfiles('   ')).toEqual(UNRESTRICTED_ENABLED_PROFILES);
+  });
+
+  it('parses comma-separated ids with trim and dedupe', () => {
+    expect(parseEnabledProfiles(' content-reader , content-developer, content-reader ')).toEqual({
+      restricted: true,
+      ids: new Set(['content-reader', 'content-developer']),
+    });
+  });
+
+  it('rejects empty CSV segments', () => {
+    expect(() => parseEnabledProfiles(',,,')).toThrow(/empty segments/);
+    expect(() => parseEnabledProfiles('content-reader,')).toThrow(/empty segments/);
+  });
+
+  it('rejects unknown ids and free-form paths', () => {
+    expect(() => parseEnabledProfiles('not-a-profile')).toThrow(/unknown profile/);
+    expect(() => parseEnabledProfiles('/content-reader/v1/mcp')).toThrow(/unknown profile/);
+    expect(() => parseEnabledProfiles('not-a-profile')).toThrow(ENV_LIGHTDASH_TOOLS_MCP_PROFILES);
+  });
+});
+
+describe('isProfileEnabled / requiresSignedStateKey / resolveRootMcpPath', () => {
+  it('treats unrestricted as all profiles enabled', () => {
+    expect(isProfileEnabled(UNRESTRICTED_ENABLED_PROFILES, 'content-governance')).toBe(true);
+    expect(isProfileEnabled(UNRESTRICTED_ENABLED_PROFILES, 'data-analyst')).toBe(true);
+    expect(requiresSignedStateKey(UNRESTRICTED_ENABLED_PROFILES)).toBe(true);
+  });
+
+  it('restricts to listed ids', () => {
+    const policy = parseEnabledProfiles('content-reader');
+    expect(isProfileEnabled(policy, 'content-reader')).toBe(true);
+    expect(isProfileEnabled(policy, 'semantic-layer')).toBe(false);
+    expect(requiresSignedStateKey(policy)).toBe(false);
+  });
+
+  it('requires signing key when developer or governance is enabled', () => {
+    expect(requiresSignedStateKey(parseEnabledProfiles('content-developer'))).toBe(true);
+    expect(requiresSignedStateKey(parseEnabledProfiles('content-governance'))).toBe(true);
+    expect(requiresSignedStateKey(parseEnabledProfiles('content-reader,content-developer'))).toBe(
+      true,
+    );
+  });
+
+  it('uses semantic-layer mcpPath when unrestricted or when that id is listed', () => {
+    expect(resolveRootMcpPath(UNRESTRICTED_ENABLED_PROFILES)).toBe(SEMANTIC_LAYER_PROFILE_PATH);
+    expect(resolveRootMcpPath(parseEnabledProfiles('semantic-layer,content-reader'))).toBe(
+      SEMANTIC_LAYER_PROFILE_PATH,
+    );
+  });
+
+  it('uses first PROFILE_IDS-enabled path when semantic-layer is omitted', () => {
+    expect(resolveRootMcpPath(parseEnabledProfiles('content-reader'))).toBe(
+      CONTENT_READER_PROFILE_PATH,
+    );
+    expect(resolveRootMcpPath(parseEnabledProfiles('content-reader,content-developer'))).toBe(
+      CONTENT_DEVELOPER_PROFILE_PATH,
+    );
+    expect(PROFILE_IDS.indexOf('content-developer')).toBeLessThan(
+      PROFILE_IDS.indexOf('content-reader'),
+    );
+  });
+
+  it('lists shipped paths when unrestricted and only enabled paths when restricted', () => {
+    expect(listEnabledProfilePaths(UNRESTRICTED_ENABLED_PROFILES)).toEqual(
+      PROFILE_IDS.map((id) => getProfile(id).path),
+    );
+    expect(listEnabledProfilePaths(parseEnabledProfiles('content-reader'))).toEqual([
+      CONTENT_READER_PROFILE_PATH,
+    ]);
+  });
+});

--- a/packages/mcp/src/config/enabled-profiles.ts
+++ b/packages/mcp/src/config/enabled-profiles.ts
@@ -1,0 +1,72 @@
+/**
+ * HTTP mount allowlist for shipped MCP profiles (ADR-0024).
+ *
+ * Canonical: `LIGHTDASH_TOOLS_MCP_PROFILES`.
+ * Unset/empty → unrestricted (all shipped paths). Non-empty → hard ceiling.
+ * Unknown ids / empty CSV segments fail closed. Stdio ignores this env.
+ */
+
+import { PROFILE_IDS, type ProfileId } from '@lightdash-tools/common';
+
+import {
+  DEFAULT_PROFILE_ID,
+  getDefaultProfile,
+  getProfile,
+  parseProfileId,
+} from '../profiles/index.js';
+
+import { ENV_LIGHTDASH_TOOLS_MCP_PROFILES } from './env.js';
+
+export type EnabledProfilesPolicy =
+  { restricted: false } | { restricted: true; ids: ReadonlySet<ProfileId> };
+
+export const UNRESTRICTED_ENABLED_PROFILES: EnabledProfilesPolicy = { restricted: false };
+
+export function parseEnabledProfiles(raw: string | undefined): EnabledProfilesPolicy {
+  if (raw === undefined || raw.trim() === '') {
+    return UNRESTRICTED_ENABLED_PROFILES;
+  }
+  const parts = raw.split(',').map((s) => s.trim());
+  if (parts.some((part) => part === '')) {
+    throw new Error(
+      `${ENV_LIGHTDASH_TOOLS_MCP_PROFILES} must be a non-empty comma-separated list of profile ids (empty segments are not allowed)`,
+    );
+  }
+  const ids = new Set<ProfileId>();
+  for (const part of parts) {
+    const id = parseProfileId(part);
+    if (!id) {
+      throw new Error(
+        `${ENV_LIGHTDASH_TOOLS_MCP_PROFILES} contains unknown profile '${part}'. Expected one of: ${PROFILE_IDS.join(', ')}`,
+      );
+    }
+    ids.add(id);
+  }
+  return { restricted: true, ids };
+}
+
+export function isProfileEnabled(policy: EnabledProfilesPolicy, id: ProfileId): boolean {
+  return !policy.restricted || policy.ids.has(id);
+}
+
+/** Preview/destructive HMAC key is required when write profiles are mounted. */
+export function requiresSignedStateKey(policy: EnabledProfilesPolicy): boolean {
+  return (
+    !policy.restricted ||
+    policy.ids.has('content-developer') ||
+    policy.ids.has('content-governance')
+  );
+}
+
+/** Enabled HTTP mount paths in `PROFILE_IDS` order. */
+export function listEnabledProfilePaths(policy: EnabledProfilesPolicy): string[] {
+  return PROFILE_IDS.filter((id) => isProfileEnabled(policy, id)).map((id) => getProfile(id).path);
+}
+
+/** Root PRM / `config.mcpPath` anchor: default profile, else first enabled `PROFILE_IDS` id. */
+export function resolveRootMcpPath(policy: EnabledProfilesPolicy): string {
+  if (!policy.restricted || policy.ids.has(DEFAULT_PROFILE_ID)) {
+    return getDefaultProfile().path;
+  }
+  return listEnabledProfilePaths(policy)[0]!;
+}

--- a/packages/mcp/src/config/env.ts
+++ b/packages/mcp/src/config/env.ts
@@ -10,6 +10,8 @@ export const ENV_PLATFORM_PORT = 'PORT';
 export const ENV_LIGHTDASH_TOOLS_MCP_PUBLIC_URL = 'LIGHTDASH_TOOLS_MCP_PUBLIC_URL';
 /** Rejected at config load — MCP path is profile-owned (see profiles/). */
 export const ENV_LIGHTDASH_TOOLS_MCP_PATH = 'LIGHTDASH_TOOLS_MCP_PATH';
+/** Optional HTTP mount allowlist (comma-separated ProfileIds). Unset/empty → all. Stdio ignores. */
+export const ENV_LIGHTDASH_TOOLS_MCP_PROFILES = 'LIGHTDASH_TOOLS_MCP_PROFILES';
 /** Rejected — auth mode is inferred from credentials (ADR-0007). */
 export const ENV_LIGHTDASH_TOOLS_MCP_AUTH_MODE = 'LIGHTDASH_TOOLS_MCP_AUTH_MODE';
 export const ENV_LIGHTDASH_TOOLS_MCP_SHARED_KEY = 'LIGHTDASH_TOOLS_MCP_SHARED_KEY';

--- a/packages/mcp/src/config/load-mcp-config.test.ts
+++ b/packages/mcp/src/config/load-mcp-config.test.ts
@@ -1,11 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  CONTENT_DEVELOPER_PROFILE_PATH,
+  CONTENT_READER_PROFILE_PATH,
+  SEMANTIC_LAYER_PROFILE_PATH,
+} from '../profiles/index.js';
+
+import { UNRESTRICTED_ENABLED_PROFILES } from './enabled-profiles.js';
+import {
   ENV_LIGHTDASH_TOOLS_MCP_ALLOWED_ORIGINS,
   ENV_LIGHTDASH_TOOLS_MCP_AUTH_MODE,
   ENV_LIGHTDASH_TOOLS_MCP_EXPERIMENTAL_IDENTITY_OAUTH,
   ENV_LIGHTDASH_TOOLS_MCP_INSECURE_DEV,
   ENV_LIGHTDASH_TOOLS_MCP_PATH,
+  ENV_LIGHTDASH_TOOLS_MCP_PROFILES,
   ENV_LIGHTDASH_TOOLS_MCP_PUBLIC_URL,
   ENV_LIGHTDASH_TOOLS_MCP_REQUIRED_SCOPES,
   ENV_LIGHTDASH_TOOLS_MCP_SCOPES_SUPPORTED,
@@ -254,6 +262,55 @@ describe('loadMcpHttpConfig', () => {
 
     const config = loadMcpHttpConfig();
     expect(config.validateToken).toBe(false);
+  });
+
+  it('keeps default mcpPath when MCP_PROFILES is unset', () => {
+    process.env.LIGHTDASH_URL = 'https://app.lightdash.cloud';
+    process.env.NODE_ENV = 'development';
+
+    const config = loadMcpHttpConfig();
+    expect(config.enabledProfiles).toEqual(UNRESTRICTED_ENABLED_PROFILES);
+    expect(config.mcpPath).toBe(SEMANTIC_LAYER_PROFILE_PATH);
+  });
+
+  it('keeps semantic-layer mcpPath when that id is in the allowlist', () => {
+    process.env.LIGHTDASH_URL = 'https://app.lightdash.cloud';
+    process.env.NODE_ENV = 'development';
+    process.env[ENV_LIGHTDASH_TOOLS_MCP_PROFILES] = 'semantic-layer, content-reader';
+
+    const config = loadMcpHttpConfig();
+    expect(config.enabledProfiles.restricted).toBe(true);
+    expect(config.mcpPath).toBe(SEMANTIC_LAYER_PROFILE_PATH);
+  });
+
+  it('uses first PROFILE_IDS-enabled mcpPath when semantic-layer is omitted', () => {
+    process.env.LIGHTDASH_URL = 'https://app.lightdash.cloud';
+    process.env.NODE_ENV = 'development';
+    process.env[ENV_LIGHTDASH_TOOLS_MCP_PROFILES] = 'content-reader,content-developer';
+
+    const config = loadMcpHttpConfig();
+    expect(config.mcpPath).toBe(CONTENT_DEVELOPER_PROFILE_PATH);
+  });
+
+  it('rejects unknown MCP_PROFILES ids and empty segments', () => {
+    process.env.LIGHTDASH_URL = 'https://app.lightdash.cloud';
+    process.env.NODE_ENV = 'development';
+    process.env[ENV_LIGHTDASH_TOOLS_MCP_PROFILES] = 'not-a-profile';
+    expect(() => loadMcpHttpConfig()).toThrow(ENV_LIGHTDASH_TOOLS_MCP_PROFILES);
+
+    process.env[ENV_LIGHTDASH_TOOLS_MCP_PROFILES] = 'content-reader,';
+    expect(() => loadMcpHttpConfig()).toThrow(/empty segments/);
+  });
+
+  it('still strips disabled profile suffixes from PUBLIC_URL', () => {
+    setOAuthCreds();
+    process.env[ENV_LIGHTDASH_TOOLS_MCP_PROFILES] = 'content-reader';
+    process.env[ENV_LIGHTDASH_TOOLS_MCP_PUBLIC_URL] =
+      'https://mcp.example.com/content-governance/v1/mcp';
+
+    const config = loadMcpHttpConfig();
+    expect(config.publicUrl).toBe('https://mcp.example.com');
+    expect(config.mcpPath).toBe(CONTENT_READER_PROFILE_PATH);
   });
 
   it('rejects LIGHTDASH_TOOLS_MCP_PATH', () => {

--- a/packages/mcp/src/config/load-mcp-config.ts
+++ b/packages/mcp/src/config/load-mcp-config.ts
@@ -12,12 +12,18 @@ import {
 import { getDefaultProfile, listProfilePaths } from '../profiles/index.js';
 
 import {
+  parseEnabledProfiles,
+  resolveRootMcpPath,
+  type EnabledProfilesPolicy,
+} from './enabled-profiles.js';
+import {
   ENV_LIGHTDASH_TOOLS_MCP_ALLOWED_ORIGINS,
   ENV_LIGHTDASH_TOOLS_MCP_HTTP_HOST,
   ENV_LIGHTDASH_TOOLS_MCP_HTTP_PORT,
   ENV_PLATFORM_PORT,
   ENV_LIGHTDASH_TOOLS_MCP_MAX_BODY_BYTES,
   ENV_LIGHTDASH_TOOLS_MCP_PATH,
+  ENV_LIGHTDASH_TOOLS_MCP_PROFILES,
   ENV_LIGHTDASH_TOOLS_MCP_PUBLIC_URL,
   ENV_LIGHTDASH_TOOLS_MCP_REQUIRED_SCOPES,
   ENV_LIGHTDASH_TOOLS_MCP_SCOPES_SUPPORTED,
@@ -178,6 +184,8 @@ export interface McpHttpConfig {
   port: number;
   publicUrl?: string;
   mcpPath: string;
+  /** HTTP mount allowlist. Unrestricted when LIGHTDASH_TOOLS_MCP_PROFILES is unset. */
+  enabledProfiles: EnabledProfilesPolicy;
   authMode: McpAuthMode;
   sharedKey?: SecretString;
   /** Server-held Lightdash OAuth application client id (broker mode). */
@@ -387,7 +395,8 @@ export function loadMcpHttpConfig(env: NodeJS.ProcessEnv = process.env): McpHttp
 
   const proxyAuth = readEnv(ENV_LIGHTDASH_PROXY_AUTHORIZATION, env);
 
-  const mcpPath = getDefaultProfile().path;
+  const enabledProfiles = parseEnabledProfiles(readEnv(ENV_LIGHTDASH_TOOLS_MCP_PROFILES, env));
+  const mcpPath = resolveRootMcpPath(enabledProfiles);
   const publicUrl = publicUrlRaw ? normalizePublicUrl(publicUrlRaw, listProfilePaths()) : undefined;
   assertPublicUrlSecurity(authMode, publicUrl);
 
@@ -419,6 +428,7 @@ export function loadMcpHttpConfig(env: NodeJS.ProcessEnv = process.env): McpHttp
     ),
     publicUrl,
     mcpPath,
+    enabledProfiles,
     authMode,
     sharedKey: sharedKeyRaw ? new SecretString(sharedKeyRaw) : undefined,
     ...resolveOAuthCredentials(authMode, oauthClientId, oauthClientSecretRaw),

--- a/packages/mcp/src/config/test-mcp-http-config.ts
+++ b/packages/mcp/src/config/test-mcp-http-config.ts
@@ -1,13 +1,17 @@
+import { UNRESTRICTED_ENABLED_PROFILES, resolveRootMcpPath } from './enabled-profiles.js';
+
 import type { McpHttpConfig } from './load-mcp-config.js';
 
 /** Shared base `McpHttpConfig` for MCP package unit/integration tests. */
 export function makeTestMcpHttpConfig(overrides?: Partial<McpHttpConfig>): McpHttpConfig {
+  const enabledProfiles = overrides?.enabledProfiles ?? UNRESTRICTED_ENABLED_PROFILES;
   return {
     lightdashUrl: 'https://app.lightdash.cloud',
     host: '127.0.0.1',
     port: 3100,
     publicUrl: 'https://mcp.example.com',
-    mcpPath: '/semantic-layer/v1/mcp',
+    mcpPath: resolveRootMcpPath(enabledProfiles),
+    enabledProfiles,
     authMode: 'lightdash-oauth',
     allowedOrigins: [],
     maxBodyBytes: 1024,

--- a/packages/mcp/src/http.integration.test.ts
+++ b/packages/mcp/src/http.integration.test.ts
@@ -5,6 +5,8 @@ import { CLIENT_CAPABILITIES_META_KEY } from '@modelcontextprotocol/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getAuthorizationServerMetadataUrl } from './auth/resource-server/oauth-protected-resource.js';
+import { parseEnabledProfiles } from './config/enabled-profiles.js';
+import { makeTestMcpHttpConfig } from './config/test-mcp-http-config.js';
 import { createStreamableHttpServer } from './transports/streamable-http.js';
 
 import type { McpHttpConfig } from './config/load-mcp-config.js';
@@ -152,23 +154,18 @@ async function startMockLightdashServer(): Promise<MockLightdashServer> {
   };
 }
 
-function baseOAuthConfig(lightdashUrl: string): McpHttpConfig {
-  return {
+function baseOAuthConfig(lightdashUrl: string, overrides?: Partial<McpHttpConfig>): McpHttpConfig {
+  return makeTestMcpHttpConfig({
     lightdashUrl,
-    host: '127.0.0.1',
     port: 0,
     publicUrl: 'http://127.0.0.1:0',
-    mcpPath: '/semantic-layer/v1/mcp',
-    authMode: 'lightdash-oauth',
     oauthClientId: 'test-client-id',
     oauthClientSecret: new SecretString('test-client-secret'),
-    allowedOrigins: [],
     maxBodyBytes: 1024 * 1024,
     requiredScopes: [],
     scopesSupported: [],
-    validateToken: true,
-    tokenValidationCacheTtlMs: 30_000,
-  };
+    ...overrides,
+  });
 }
 
 async function postMcp(
@@ -662,6 +659,60 @@ describe('MCP HTTP transport (sessionless)', () => {
   });
 });
 
+describe('MCP HTTP profile mount allowlist', () => {
+  let mockLightdash: MockLightdashServer;
+  let mcpServer: McpHttpServer;
+
+  beforeEach(async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    mockLightdash = await startMockLightdashServer();
+    mcpServer = await createStreamableHttpServer(
+      baseOAuthConfig(mockLightdash.baseUrl, {
+        enabledProfiles: parseEnabledProfiles('content-reader'),
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    await mcpServer.close();
+    await mockLightdash.close();
+    vi.restoreAllMocks();
+  });
+
+  it('404s disabled profile MCP paths and their path-specific PRM', async () => {
+    const mcpResponse = await postMcp(mcpServer.baseUrl, INITIALIZE_BODY, { token: TOKEN_A });
+    expect(mcpResponse.status).toBe(404);
+
+    const prmResponse = await fetch(
+      `${mcpServer.baseUrl}/.well-known/oauth-protected-resource/semantic-layer/v1/mcp`,
+    );
+    expect(prmResponse.status).toBe(404);
+  });
+
+  it('keeps enabled profile MCP and PRM reachable', async () => {
+    const mcpResponse = await postMcp(mcpServer.baseUrl, INITIALIZE_BODY, {
+      token: TOKEN_A,
+      path: '/content-reader/v1/mcp',
+    });
+    expect(mcpResponse.status).toBe(200);
+
+    const prmResponse = await fetch(
+      `${mcpServer.baseUrl}/.well-known/oauth-protected-resource/content-reader/v1/mcp`,
+    );
+    expect(prmResponse.status).toBe(200);
+    const metadata = (await prmResponse.json()) as { resource: string };
+    expect(metadata.resource).toBe(`${mcpServer.baseUrl}/content-reader/v1/mcp`);
+  });
+
+  it('serves root PRM for the first enabled profile path', async () => {
+    const response = await fetch(`${mcpServer.baseUrl}/.well-known/oauth-protected-resource`);
+    expect(response.status).toBe(200);
+    const metadata = (await response.json()) as { resource: string };
+    expect(metadata.resource).toBe(`${mcpServer.baseUrl}/content-reader/v1/mcp`);
+  });
+});
+
 describe('MCP HTTP shared-key integration', () => {
   let mcpServer: McpHttpServer;
   const originalEnv = { ...process.env };
@@ -672,20 +723,18 @@ describe('MCP HTTP shared-key integration', () => {
     process.env.LIGHTDASH_URL = 'https://app.lightdash.cloud';
     process.env.LIGHTDASH_API_KEY = 'ldpat_test_key';
 
-    mcpServer = await createStreamableHttpServer({
-      lightdashUrl: 'https://app.lightdash.cloud',
-      host: '127.0.0.1',
-      port: 0,
-      mcpPath: '/semantic-layer/v1/mcp',
-      authMode: 'shared-key',
-      sharedKey: new SecretString('shared-secret'),
-      allowedOrigins: [],
-      maxBodyBytes: 1024 * 1024,
-      requiredScopes: [],
-      scopesSupported: ['mcp:read'],
-      validateToken: false,
-      tokenValidationCacheTtlMs: 30_000,
-    });
+    mcpServer = await createStreamableHttpServer(
+      makeTestMcpHttpConfig({
+        port: 0,
+        publicUrl: undefined,
+        authMode: 'shared-key',
+        sharedKey: new SecretString('shared-secret'),
+        maxBodyBytes: 1024 * 1024,
+        requiredScopes: [],
+        scopesSupported: ['mcp:read'],
+        validateToken: false,
+      }),
+    );
   });
 
   afterEach(async () => {

--- a/packages/mcp/src/index.integration.test.ts
+++ b/packages/mcp/src/index.integration.test.ts
@@ -6,10 +6,9 @@ import { describe, it, expect } from 'vitest';
 import { EnvContextProvider } from './auth/providers/env-context-provider.js';
 import { validateLightdashAccessToken } from './auth/resource-server/lightdash-token-validation.js';
 import { getClient } from './config/runtime.js';
+import { makeTestMcpHttpConfig } from './config/test-mcp-http-config.js';
 import { createLightdashMcpServer } from './server/server.js';
 import { TOOL_PREFIX } from './tools/shared';
-
-import type { McpHttpConfig } from './config/load-mcp-config.js';
 
 const hasCredentials = !!process.env.LIGHTDASH_API_KEY && !!process.env.LIGHTDASH_URL;
 const hasOAuthToken =
@@ -67,20 +66,10 @@ describe.runIf(hasOAuthToken)('MCP Integration (OAuth access token)', () => {
   it('validates live OAuth bearer token against Lightdash via GET /api/v1/user', async () => {
     const lightdashUrl = process.env.LIGHTDASH_URL!.replace(/\/$/, '');
     const accessToken = process.env.LIGHTDASH_TOOLS_TEST_OAUTH_ACCESS_TOKEN!;
-    const config: McpHttpConfig = {
+    const config = makeTestMcpHttpConfig({
       lightdashUrl,
-      host: '127.0.0.1',
-      port: 3100,
-      publicUrl: 'https://mcp.example.com',
-      mcpPath: '/semantic-layer/v1/mcp',
-      authMode: 'lightdash-oauth',
-      allowedOrigins: [],
       maxBodyBytes: 1024 * 1024,
-      requiredScopes: ['mcp:read'],
-      scopesSupported: ['mcp:read', 'mcp:write'],
-      validateToken: true,
-      tokenValidationCacheTtlMs: 30_000,
-    };
+    });
 
     const user = await validateLightdashAccessToken(config, accessToken);
 

--- a/packages/mcp/src/profiles/index.ts
+++ b/packages/mcp/src/profiles/index.ts
@@ -1,5 +1,6 @@
 /**
- * Shipped MCP profiles (path → definition). No PROFILE/PATH env knobs (ADR-0006).
+ * Shipped MCP profiles (path → definition). No free-form PATH env (ADR-0006).
+ * HTTP may filter mounts via LIGHTDASH_TOOLS_MCP_PROFILES (ADR-0024); catalog stays complete.
  */
 
 import { PROFILE_IDS } from '@lightdash-tools/common';

--- a/packages/mcp/src/transports/streamable-http.test.ts
+++ b/packages/mcp/src/transports/streamable-http.test.ts
@@ -5,6 +5,7 @@ import {
   getAuthorizationServerMetadataUrl,
 } from '../auth/resource-server/oauth-protected-resource.js';
 import { buildWwwAuthenticateHeader } from '../auth/resource-server/www-authenticate.js';
+import { parseEnabledProfiles } from '../config/enabled-profiles.js';
 import {
   ENV_LIGHTDASH_TOOLS_MCP_AUTH_MODE,
   ENV_LIGHTDASH_TOOLS_MCP_PUBLIC_URL,
@@ -139,6 +140,26 @@ describe('streamable HTTP OAuth metadata', () => {
     await expect(createStreamableHttpServer(makeTestMcpHttpConfig({ port: 0 }))).rejects.toThrow(
       /LIGHTDASH_TOOLS_MCP_REQUEST_STATE_KEY/,
     );
+
+    if (savedVitest !== undefined) {
+      process.env.VITEST = savedVitest;
+    }
+  });
+
+  it('allows HTTP startup without request-state key when write profiles are disabled', async () => {
+    const savedVitest = process.env.VITEST;
+    delete process.env.VITEST;
+    process.env.NODE_ENV = 'production';
+    delete process.env[ENV_LIGHTDASH_TOOLS_MCP_REQUEST_STATE_KEY];
+
+    const handle = await createStreamableHttpServer(
+      makeTestMcpHttpConfig({
+        port: 0,
+        enabledProfiles: parseEnabledProfiles('content-reader'),
+      }),
+    );
+    expect(handle.port).toBeGreaterThan(0);
+    await handle.close();
 
     if (savedVitest !== undefined) {
       process.env.VITEST = savedVitest;

--- a/packages/mcp/src/transports/streamable-http.ts
+++ b/packages/mcp/src/transports/streamable-http.ts
@@ -30,6 +30,11 @@ import {
 import { authenticateSharedKey } from '../auth/resource-server/shared-key-middleware.js';
 import { hashToken } from '../auth/token-hash.js';
 import {
+  isProfileEnabled,
+  listEnabledProfilePaths,
+  requiresSignedStateKey,
+} from '../config/enabled-profiles.js';
+import {
   getOAuthCallbackUrl,
   loadMcpHttpConfig,
   requiresLightdashApiKey,
@@ -46,7 +51,7 @@ import {
   extractPinnedProjectFromRequest,
   runWithProjectPinAsync,
 } from '../governance/project-pin.js';
-import { getProfileByPath, listProfilePaths } from '../profiles/index.js';
+import { getProfileByPath } from '../profiles/index.js';
 import { createLightdashMcpServer } from '../server/server.js';
 
 import { parseJsonBody, readBody, drainRequestBody } from './http-body.js';
@@ -279,7 +284,9 @@ export async function createStreamableHttpServer(
 
   warnIgnoredCliGuardrailEnvVars();
   validateAvailableProjectsConfig();
-  assertHttpSignedStateKeyConfigured();
+  if (requiresSignedStateKey(inputConfig.enabledProfiles)) {
+    assertHttpSignedStateKeyConfigured();
+  }
   initAuditLog(getAuditLogPath());
 
   let httpConfig = inputConfig;
@@ -329,7 +336,7 @@ export async function createStreamableHttpServer(
 export function startStreamableHttpServer(config?: McpHttpConfig): void {
   void createStreamableHttpServer(config)
     .then(({ baseUrl, config: httpConfig }) => {
-      const paths = listProfilePaths()
+      const paths = listEnabledProfilePaths(httpConfig.enabledProfiles)
         .map((p) => `${baseUrl}${p}`)
         .join(', ');
       console.error(`Lightdash MCP server listening on ${paths} (auth: ${httpConfig.authMode})`);
@@ -444,7 +451,7 @@ async function handleHttpRequest(
   }
 
   const profile = getProfileByPath(path);
-  if (!profile) {
+  if (!profile || !isProfileEnabled(config.enabledProfiles, profile.id)) {
     sendJson(res, 404, { error: 'Not Found' });
     return;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,8 @@ settings:
 
 overrides:
   form-data: '>=4.0.6'
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
+  nanoid: 3.3.17
   minimatch: '>=5.1.8'
   semver: '>=7.8.4'
   tar: '>=7.5.19'
@@ -102,7 +103,7 @@ importers:
         version: link:../common
       axios:
         specifier: '>=1.18.0'
-        version: 1.19.0
+        version: 1.19.0(supports-color@10.2.2)
       bottleneck:
         specifier: ^2.19.5
         version: 2.19.5
@@ -1493,8 +1494,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -1655,8 +1656,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2400,7 +2401,7 @@ snapshots:
       colorette: 1.4.0
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       js-levenshtein: 1.1.6
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 10.2.5
       pluralize: 8.0.0
       yaml-ast-parser: 0.0.43
@@ -2778,7 +2779,7 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
@@ -2807,11 +2808,11 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.19.0:
+  axios@1.19.0(supports-color@10.2.2):
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@10.2.2)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -3206,9 +3207,9 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@10.2.2):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@10.2.2)
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
@@ -3280,7 +3281,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -3418,7 +3419,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -3534,7 +3535,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,6 +26,7 @@ minimumReleaseAgeExclude:
   - fast-uri
   - tar
   - js-yaml
+  - nanoid
   - '@modelcontextprotocol/server'
   - '@modelcontextprotocol/node'
   - '@modelcontextprotocol/client'
@@ -38,7 +39,8 @@ minimumReleaseAgeExclude:
 
 overrides:
   form-data: '>=4.0.6'
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
+  nanoid: 3.3.17
   minimatch: '>=5.1.8'
   semver: '>=7.8.4'
   tar: '>=7.5.19'


### PR DESCRIPTION
## Summary
- Add `LIGHTDASH_TOOLS_MCP_PROFILES` as an HTTP-only mount ceiling (comma-separated known profile ids; unset/empty = all seven shipped paths).
- Disabled MCP paths and their RFC 9728 PRM well-known routes 404; `REQUEST_STATE_KEY` is required only when `content-developer` or `content-governance` is mounted.
- Stdio is unchanged (`stdio --profile <id>` only; this env is ignored). ADR-0024 amends ADR-0006.

## Test plan
- [ ] `pnpm verify:pr` (or wait for CI)
- [ ] Parser/config: unset/empty = all; unknown ids and empty CSV segments fail closed; `mcpPath` follows default profile or first enabled `PROFILE_IDS` id
- [ ] HTTP: restricted `content-reader` 404s other profile MCP + PRM; enabled path and root PRM still work
- [ ] HTTP startup without `LIGHTDASH_TOOLS_MCP_REQUEST_STATE_KEY` succeeds when write profiles are not mounted
- [ ] Stdio still requires `--profile` and ignores `LIGHTDASH_TOOLS_MCP_PROFILES`


Made with [Cursor](https://cursor.com)