### PR TITLE
chore: bump version to 0.14.0

### DIFF
--- a/.changes/0.14.0.
+++ b/.changes/0.14.0.
@@ -1,0 +1,5 @@
+## [0.14.0] - 2026-08-10
+### Features
+* MCP HTTP: optional LIGHTDASH_TOOLS_MCP_PROFILES allowlist to mount a subset of fixed profile paths.
+### Bug Fixes
+* Bump js-yaml to 4.3.1 and nanoid to 3.3.17 to remediate High SBOM findings (GHSA-5p4m-2wfm-xmqj, GHSA-2v37-7h3g-55p8).

--- a/.changes/unreleased/feat-20260810-085735.yaml
+++ b/.changes/unreleased/feat-20260810-085735.yaml
@@ -1,3 +1,0 @@
-kind: feat
-body: 'MCP HTTP: optional LIGHTDASH_TOOLS_MCP_PROFILES allowlist to mount a subset of fixed profile paths.'
-time: 2026-08-10T08:57:35.884372+09:00

--- a/.changes/unreleased/fix-20260810-095306.yaml
+++ b/.changes/unreleased/fix-20260810-095306.yaml
@@ -1,3 +1,0 @@
-kind: fix
-body: Bump js-yaml to 4.3.1 and nanoid to 3.3.17 to remediate High SBOM findings (GHSA-5p4m-2wfm-xmqj, GHSA-2v37-7h3g-55p8).
-time: 2026-08-10T09:53:06.502972+09:00

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,7 @@ Additional specialized skills are documented in `CLAUDE.md`.
 - Trunk: `@trunkio/launcher` + `pnpm trunk:install`; restricted network → `pnpm lint:eslint` / `format:eslint` / `format:prettier`.
 - pnpm v11: `overrides` live in `pnpm-workspace.yaml`; keep lockfile committed; `packageManager` is `pnpm@11.5.3`. Use exact pins (or `~`) for security bumps — `>=x.y.z` can pull the next major.
 - Build before ESLint (`dist/` resolves); prefer root `pnpm exec vitest run <files>` over per-package `test:fast`.
-- Changie: `kindFormat: '### {{.Kind}}'`; fragments use kind keys (`feat`/`fix`), not Keep-a-Changelog labels.
+- Changie: `kindFormat: '### {{.Kind}}'`; fragments use kind keys (`feat`/`fix`), not Keep-a-Changelog labels. After `changie merge`, Trunk/Prettier reformats CHANGELOG.md (`*` → `-`, blank lines).
 - `pnpm -r version` needs a clean tree — bump `packages/*/package.json` versions directly if dirty.
 - Agent surface: MCP profiles own mounts via `tools: ToolModule[]` imports (ADR-0022); irrecoverable tool ids stay on `IRRECOVERABLE_TOOL_DENYLIST` (ADR-0004).
 - MCP: `registerToolSafe()` only; CLI: `wrapAction()`; serving profile via `bindServerProfile` + profile `tools` array.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.14.0] - 2026-08-10
+
+### Features
+
+- MCP HTTP: optional LIGHTDASH_TOOLS_MCP_PROFILES allowlist to mount a subset of fixed profile paths.
+
+### Bug Fixes
+
+- Bump js-yaml to 4.3.1 and nanoid to 3.3.17 to remediate High SBOM findings (GHSA-5p4m-2wfm-xmqj, GHSA-2v37-7h3g-55p8).
+
 ## [0.13.2] - 2026-08-06
 
 ## [0.13.1] - 2026-08-06

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ Use the `/improve-claude-config` skill to orchestrate deeper changes.
 
 ## Recent Learnings
 
+- [2026-08-10]: After `changie merge`, Trunk/Prettier rewrites CHANGELOG.md (`*` bullets → `-`, blank lines around headings). Format before claiming lint clean.
 - [2026-08-10]: pnpm `overrides` with `>=x.y.z` can jump majors (`js-yaml` 4→5, `nanoid` 3→6). Pin exact patched lines (4.3.1 / 3.3.17) for SBOM High CVEs.
 - [2026-08-10]: HTTP `LIGHTDASH_TOOLS_MCP_PROFILES` is a mount allowlist (unset = all seven paths); stdio still requires `--profile` and ignores this env. Disabled paths and their RFC 9728 PRM 404.
 - [2026-08-07]: content-reader verified discovery is `list_verified_content` → `GET …/content-verification`; `search_content` / OpenAPI v2 content list has no `verifiedOnly` filter — prompt preference flags must call the dedicated tool.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "private": true,
   "description": "",
   "keywords": [],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/cli",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "CLI for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,7 +35,7 @@ const program = new Command();
 program
   .name('lightdash-ai')
   .description('CLI for Lightdash AI')
-  .version('0.13.2')
+  .version('0.14.0')
   .option(
     '--safety-mode <mode>',
     'Safety mode (read-only, write-idempotent, write-destructive)',

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/client",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "Client library for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/common",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "Shared utilities and types for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/mcp",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "MCP server for Lightdash semantic-layer, organization-audit, content-reader, content-developer, content-governance, and ai-agent-ops profiles.",
   "keywords": [],
   "repository": {


### PR DESCRIPTION
## Summary
- Bump all workspace packages from 0.13.2 to 0.14.0
- Sync CLI entrypoint version string
- Batch changelog: MCP HTTP `LIGHTDASH_TOOLS_MCP_PROFILES` allowlist; js-yaml/nanoid SBOM pins

## Test plan
- [ ] CI passes on this branch
- [ ] Verify published package versions match 0.14.0 after merge


Made with [Cursor](https://cursor.com)