### PR TITLE
docs(mcp): document HTTP health probes

### DIFF
--- a/.changes/unreleased/docs-20260810-111919.yaml
+++ b/.changes/unreleased/docs-20260810-111919.yaml
@@ -1,0 +1,3 @@
+kind: docs
+body: Document MCP HTTP health probes (/health/live, /health/ready) in the package README and Cloud Run operator guide.
+time: 2026-08-10T11:19:19.772527+09:00

--- a/docs/operators/cloud-run.md
+++ b/docs/operators/cloud-run.md
@@ -23,6 +23,31 @@ ENV LIGHTDASH_TOOLS_MCP_HTTP_PORT=8080
 CMD ["node", "packages/mcp/dist/bin.js", "http"]
 ```
 
+## Health probes
+
+Unauthenticated HTTP probes (always mounted, including when `LIGHTDASH_TOOLS_MCP_PROFILES` restricts MCP paths). They are not MCP tools and do not require OAuth. Prefer **`GET /health/live`** for Cloud Run [startup and liveness](https://docs.cloud.google.com/run/docs/configuring/healthchecks) — same path Compose uses. Contract: [packages/mcp/README.md](../../packages/mcp/README.md).
+
+| Path            | When to use        | Success                       | Notes                                                                                      |
+| :-------------- | :----------------- | :---------------------------- | :----------------------------------------------------------------------------------------- |
+| `/health/live`  | startup + liveness | `200` `{ "status": "ok" }`    | Process is listening                                                                       |
+| `/health/ready` | optional readiness | `200` `{ "status": "ready" }` | `503` if an API-key client cannot be constructed; hosted OAuth has no key, so ready ≈ live |
+
+```bash
+curl -fsS http://127.0.0.1:8080/health/live
+```
+
+Example deploy flags (container port `8080`):
+
+```bash
+gcloud run deploy lightdash-mcp \
+  --image=gcr.io/PROJECT_ID/lightdash-mcp \
+  --port=8080 \
+  --startup-probe=httpGet.path=/health/live,httpGet.port=8080,periodSeconds=10,timeoutSeconds=1,failureThreshold=3 \
+  --liveness-probe=httpGet.path=/health/live,httpGet.port=8080,periodSeconds=10,timeoutSeconds=1,failureThreshold=3
+```
+
+Do not treat `/health/ready` as an upstream Lightdash dependency check in hosted OAuth mode.
+
 ## Cloud Run environment variables
 
 ```bash
@@ -119,3 +144,4 @@ gcloud run deploy lightdash-mcp \
 - [ ] Audit sink / retention configured if compliance requires >30 days
 - [ ] `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS` set when the service must not see the whole org
 - [ ] `LIGHTDASH_TOOLS_MCP_PROFILES` set when the service must not mount every persona
+- [ ] Startup / liveness probe is `GET /health/live` on the container port

--- a/docs/operators/cursor-claude.md
+++ b/docs/operators/cursor-claude.md
@@ -51,7 +51,7 @@ Use Cloudflare quick tunnel so Cursor’s post-callback Mozilla GETs to PRM/AS m
 
 2. Copy the printed `https://*.trycloudflare.com` URL into gitignored `.env` as `LIGHTDASH_TOOLS_MCP_PUBLIC_URL`, and into `.cursor/mcp.json` as the MCP `url` host (`…/semantic-layer/v1/mcp`).
 
-3. Start (or recreate) MCP so it picks up `.env`. Wait for `healthy` in `docker compose -f docker-compose.dev.yml ps` before relying on the tunnel:
+3. Start (or recreate) MCP so it picks up `.env`. Wait for `healthy` in `docker compose -f docker-compose.dev.yml ps` (Compose probes `GET /health/live`) before relying on the tunnel:
 
    ```bash
    docker compose -f docker-compose.dev.yml up --build -d

--- a/docs/operators/mcp-oauth.md
+++ b/docs/operators/mcp-oauth.md
@@ -43,6 +43,9 @@ npx @lightdash-tools/mcp http
 Verify:
 
 ```bash
+curl -fsS "https://lightdash-mcp.example.com/health/live"
+# {"status":"ok"} — unauthenticated process probe (not OAuth)
+
 curl -s "https://lightdash-mcp.example.com/.well-known/oauth-protected-resource" | jq .
 # authorization_servers: ["https://lightdash-mcp.example.com"]
 
@@ -99,14 +102,15 @@ CLI-only (ignored for MCP auth): `LIGHTDASH_TOOLS_SAFETY_MODE`, `DRY_RUN`. Share
 
 ## Broker routes
 
-| Path                                      | Purpose                                                       |
-| :---------------------------------------- | :------------------------------------------------------------ |
-| `/oauth/authorize`                        | Start client OAuth; redirect to Lightdash with fixed callback |
-| `/oauth/callback`                         | Lightdash redirect; exchange code with client secret          |
-| `/oauth/token`                            | Client token exchange (PKCE)                                  |
-| `/oauth/register`                         | Thin DCR stub (public client)                                 |
-| `/.well-known/oauth-authorization-server` | Broker AS metadata                                            |
-| `/.well-known/oauth-protected-resource`   | PRM (`authorization_servers` = `PUBLIC_URL`)                  |
+| Path                                      | Purpose                                                                      |
+| :---------------------------------------- | :--------------------------------------------------------------------------- |
+| `/oauth/authorize`                        | Start client OAuth; redirect to Lightdash with fixed callback                |
+| `/oauth/callback`                         | Lightdash redirect; exchange code with client secret                         |
+| `/oauth/token`                            | Client token exchange (PKCE)                                                 |
+| `/oauth/register`                         | Thin DCR stub (public client)                                                |
+| `/.well-known/oauth-authorization-server` | Broker AS metadata                                                           |
+| `/.well-known/oauth-protected-resource`   | PRM (`authorization_servers` = `PUBLIC_URL`)                                 |
+| `/health/live`, `/health/ready`           | Unauthenticated process probes (not OAuth; see [cloud-run.md](cloud-run.md)) |
 
 ## Related
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -68,10 +68,19 @@ npx @lightdash-tools/mcp http
 
 Profile MCP endpoints accept **POST** only ([Streamable HTTP 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http); no protocol sessions). Default listen port: `3100` (`LIGHTDASH_TOOLS_MCP_HTTP_PORT`). On Cloud Run / containers, when that env is unset, the platform `PORT` is used.
 
+HTTP process probes (unauthenticated, not MCP tools; always mounted even when `LIGHTDASH_TOOLS_MCP_PROFILES` restricts profile paths). Stdio has no health paths.
+
+| Path                | Typical use                            | Success                       | Failure                           |
+| :------------------ | :------------------------------------- | :---------------------------- | :-------------------------------- |
+| `GET /health/live`  | Liveness / Compose / Cloud Run startup | `200` `{ "status": "ok" }`    | process down                      |
+| `GET /health/ready` | Readiness (shared-key / local `none`)  | `200` `{ "status": "ready" }` | `503` `{ "status": "not ready" }` |
+
+`/health/ready` only checks that a Lightdash API client can be constructed when the process uses an API key. Hosted OAuth mode does not require a key, so ready ≈ live — it does **not** ping upstream Lightdash. Probe recipe: [cloud-run.md](../../docs/operators/cloud-run.md).
+
 - Hosted OAuth (Cursor URL-only): [docs/operators/cursor-claude.md](../../docs/operators/cursor-claude.md)
 - Operator guide: [docs/operators/mcp-oauth.md](../../docs/operators/mcp-oauth.md)
 
-Local Compose smoke: `docker compose -f docker-compose.dev.yml up --build` → `http://localhost:8080/semantic-layer/v1/mcp`.
+Local Compose smoke: `docker compose -f docker-compose.dev.yml up --build` → `http://localhost:8080/semantic-layer/v1/mcp` (Compose healthcheck is `GET /health/live`).
 
 ## Configuration
 
@@ -215,20 +224,11 @@ When a tool handler throws (for example a Lightdash HTTP/API failure), MCP retur
 
 Intentional API upgrades still go through the pinned OpenAPI sync (`config/lightdash-openapi-ref.txt`). This layer only makes runtime drift fail safely and legibly.
 
-## Migration from `@lightdash-tools/semantic-layer-mcp`
-
-| Removed / old                                 | Use instead                               |
-| :-------------------------------------------- | :---------------------------------------- |
-| `@lightdash-tools/semantic-layer-mcp`         | `@lightdash-tools/mcp`                    |
-| Binary `lightdash-semantic-layer-mcp`         | `lightdash-mcp`                           |
-| HTTP `/mcp` (old)                             | `/semantic-layer/v1/mcp`                  |
-| Unprefixed tool names                         | `lightdash_*`                             |
-| `lightdash-mcp <profile>` / `stdio <profile>` | `lightdash-mcp stdio --profile <profile>` |
-
 ## Further reading
 
 - Architecture / contributing — [CONTRIBUTING.md](./CONTRIBUTING.md)
 - OAuth operator guide — [docs/operators/mcp-oauth.md](../../docs/operators/mcp-oauth.md)
+- Cloud Run — [docs/operators/cloud-run.md](../../docs/operators/cloud-run.md)
 - Cursor hosted OAuth — [docs/operators/cursor-claude.md](../../docs/operators/cursor-claude.md)
 - Architecture decisions — [docs/adr/](../../docs/adr/)
 - MCP transports — [2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports)


### PR DESCRIPTION
## Summary
- Document unauthenticated `GET /health/live` and `GET /health/ready` in the MCP package README (always mounted, not MCP tools; stdio has no health paths).
- Add Cloud Run startup/liveness probe recipe and checklist; mention probes in OAuth verify + Compose Cursor setup.
- Drop the completed `@lightdash-tools/semantic-layer-mcp` migration table from the README.

## Test plan
- [ ] Confirm README table matches `handleHealth` in `packages/mcp/src/transports/streamable-http.ts` (live 200 `ok`; ready 200 `ready` / 503 `not ready`).
- [ ] Confirm Cloud Run `gcloud` flags use `httpGet.path=/health/live` on port 8080.
- [ ] Confirm Compose still healthchecks `/health/live` as documented.
- [ ] Wait for CI to pass before marking ready for review.


Made with [Cursor](https://cursor.com)