### PR TITLE
chore: add Cursor sandbox policy

### DIFF
--- a/.cursor/sandbox.json
+++ b/.cursor/sandbox.json
@@ -1,0 +1,16 @@
+{
+  "type": "workspace_readwrite",
+  "enableSharedBuildCache": true,
+  "networkPolicy": {
+    "default": "deny",
+    "allow": [
+      "github.com",
+      "api.github.com",
+      "codeload.github.com",
+      "*.githubusercontent.com",
+      "registry.npmjs.org",
+      "nodejs.org",
+      "*.trunk.io"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add repo-local `.cursor/sandbox.json`
- use workspace read/write sandboxing
- deny outbound network access by default
- allow only GitHub, npm/Node, and Trunk endpoints used by the repository
- enable shared build caches

## Validation
- policy follows the current Cursor `sandbox.json` schema
- allowlist reflects the repository's pnpm/Node and Trunk workflows