### PR TITLE
fix(mcp): separate MCP OAuth tokens from Lightdash credentials

### DIFF
--- a/.github/workflows/trunk_check.yml
+++ b/.github/workflows/trunk_check.yml
@@ -52,17 +52,5 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build packages
         run: pnpm build
-      - name: Print OAuth formatting diff
-        run: |
-          pnpm exec prettier --write \
-            packages/mcp/src/auth/oauth-broker/mcp-access-token.ts \
-            packages/mcp/src/auth/oauth-broker/routes.test.ts \
-            packages/mcp/src/auth/resource-server/lightdash-oauth-middleware.ts \
-            packages/mcp/src/auth/resource-server/lightdash-oauth-middleware.test.ts
-          git diff -- \
-            packages/mcp/src/auth/oauth-broker/mcp-access-token.ts \
-            packages/mcp/src/auth/oauth-broker/routes.test.ts \
-            packages/mcp/src/auth/resource-server/lightdash-oauth-middleware.ts \
-            packages/mcp/src/auth/resource-server/lightdash-oauth-middleware.test.ts
       - name: Trunk Check
         uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4

--- a/.github/workflows/trunk_check.yml
+++ b/.github/workflows/trunk_check.yml
@@ -52,5 +52,17 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build packages
         run: pnpm build
+      - name: Print OAuth formatting diff
+        run: |
+          pnpm exec prettier --write \
+            packages/mcp/src/auth/oauth-broker/mcp-access-token.ts \
+            packages/mcp/src/auth/oauth-broker/routes.test.ts \
+            packages/mcp/src/auth/resource-server/lightdash-oauth-middleware.ts \
+            packages/mcp/src/auth/resource-server/lightdash-oauth-middleware.test.ts
+          git diff -- \
+            packages/mcp/src/auth/oauth-broker/mcp-access-token.ts \
+            packages/mcp/src/auth/oauth-broker/routes.test.ts \
+            packages/mcp/src/auth/resource-server/lightdash-oauth-middleware.ts \
+            packages/mcp/src/auth/resource-server/lightdash-oauth-middleware.test.ts
       - name: Trunk Check
         uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,8 @@ Use the `/improve-claude-config` skill to orchestrate deeper changes.
 - [2026-08-11]: MCP prompts default to progressive-disclosure `compact` (ADR-0025 / RFC); roll back with `LIGHTDASH_TOOLS_MCP_PROMPT_CONTEXT=embedded`. Invariants live in per-profile `invariants.ts` — do not paste HARD_BANS into prompt task text.
 - [2026-08-10]: OpenAPI sync is pin-first: write a release commit SHA to `config/lightdash-openapi-ref.txt`, then `pnpm --filter @lightdash-tools/common generate:types` — skills that implied always-from-`main` were wrong.
 - [2026-08-10]: After `changie merge`, Trunk/Prettier rewrites CHANGELOG.md (`*` bullets → `-`, blank lines around headings). Format before claiming lint clean.
-- [2026-08-10]: pnpm `overrides` with `>=x.y.z` can jump majors (`js-yaml` 4→5, `nanoid` 3→6). Pin exact patched lines (4.3.1 / 3.3.17) for SBOM High CVEs.
+- [2026-08-17]: Grype/GHSA-2v37-7h3g-55p8 now treats `nanoid` `<3.3.18` as High; pin exact `nanoid: 3.3.18` (not `>=`) — `3.3.17` was the prior pin and fails SBOM.
+- [2026-08-10]: pnpm `overrides` with `>=x.y.z` can jump majors (`js-yaml` 4→5, `nanoid` 3→6). Pin exact patched lines (4.3.1 / 3.3.18) for SBOM High CVEs.
 - [2026-08-10]: HTTP `LIGHTDASH_TOOLS_MCP_PROFILES` is a mount allowlist (unset = all seven paths); stdio still requires `--profile` and ignores this env. Disabled paths and their RFC 9728 PRM 404.
 - [2026-08-07]: content-reader verified discovery is `list_verified_content` → `GET …/content-verification`; `search_content` / OpenAPI v2 content list has no `verifiedOnly` filter — prompt preference flags must call the dedicated tool.
 - [2026-08-07]: PoP on content-developer: prefer cloned metrics with `generationType: periodOverPeriod` from seeds; table calculations remain the fallback when seeds lack native PoP (Explorer “Add period comparison” UI is unavailable on MCP).

--- a/docs/adr/0007-mcp-http-transport-auth-modes-sdk-v2.md
+++ b/docs/adr/0007-mcp-http-transport-auth-modes-sdk-v2.md
@@ -8,6 +8,8 @@ Accepted
 
 Amended by [19. MCP stateless protocol core without Redis ephemeral store](0019-mcp-stateless-protocol-core-without-redis-ephemeral-store.md)
 
+Amended by [26. MCP OAuth uses a dual-leg, resource-bound token boundary](0026-mcp-oauth-dual-leg-token-boundary.md)
+
 ## Context
 
 `@lightdash-tools/mcp` must serve STDIO (local agents) and Streamable HTTP (remote). Hosted HTTP needs per-user Lightdash identity. Operators register one Lightdash OAuth application per MCP deployment; the **client secret must not** be shipped to Claude Code / Cursor.

--- a/docs/adr/0026-mcp-oauth-dual-leg-token-boundary.md
+++ b/docs/adr/0026-mcp-oauth-dual-leg-token-boundary.md
@@ -1,0 +1,92 @@
+# 26. MCP OAuth uses a dual-leg, resource-bound token boundary
+
+Date: 2026-08-17
+
+## Status
+
+Accepted
+
+## Context
+
+The hosted HTTP MCP server is both:
+
+1. an OAuth protected resource for MCP clients such as Cursor, Claude Code, and Codex; and
+2. an OAuth client of the downstream Lightdash API.
+
+These are separate OAuth trust boundaries with different clients and protected resources.
+
+The original broker exchanged the Lightdash authorization code using the server-held confidential Lightdash client, then returned the resulting Lightdash access token unchanged from the MCP `/oauth/token` endpoint. The MCP resource server accepted that same token, validated it via Lightdash `GET /api/v1/user`, and forwarded it to Lightdash for tool calls.
+
+That design preserved the user's Lightdash RBAC, but it made the downstream Lightdash credential also serve as the MCP access token. It therefore could not enforce that the bearer was issued specifically for the MCP server or for a particular profile endpoint. It also meant an MCP client that received the token could potentially use the same bearer directly against Lightdash.
+
+Current MCP authorization requires clients to identify the target MCP resource with RFC 8707 `resource` in both authorization and token requests, and requires MCP resource servers to accept only tokens intended for their own resources. MCP security guidance explicitly treats accepting an upstream-issued token and passing it through to the downstream API as token passthrough.
+
+## Decision
+
+Hosted Lightdash OAuth uses two explicit authorization legs:
+
+```text
+MCP client
+    |
+    | MCP OAuth: broker-issued access token
+    | audience = exact enabled MCP profile resource
+    v
+lightdash-tools MCP server
+    |
+    | server-held delegated Lightdash access token
+    v
+Lightdash API
+```
+
+### MCP client -> broker leg
+
+- The MCP authorization request MUST contain exactly one `resource` identifying an enabled profile endpoint on the configured MCP public URL.
+- The broker binds that resource to its pending authorization state and one-time authorization code.
+- The MCP token request MUST contain the same `resource`; a mismatch fails with `invalid_grant`.
+- The broker MUST NOT return the downstream Lightdash access token to the MCP client.
+- `/oauth/token` mints a short-lived `ldmcp1.*` bearer token issued by lightdash-tools.
+- The token is authenticated-encrypted with AES-256-GCM. A purpose-specific encryption key is derived from the server-held Lightdash OAuth client secret; every replica already needs that secret.
+- The encrypted payload binds the MCP client ID, exact MCP resource URI, MCP scope, issuance/expiry timestamps, and the server-held downstream credential.
+- The MCP resource server decrypts and authenticates the token and requires an exact resource match before any Lightdash network request.
+- Raw Lightdash bearer tokens, malformed tokens, expired tokens, tampered tokens, and tokens issued for another profile are rejected locally with HTTP 401.
+
+### Broker -> Lightdash leg
+
+- The server-held Lightdash OAuth client ID/secret are used for the downstream authorization-code exchange.
+- The resulting Lightdash access token remains server-side.
+- Client PKCE, MCP `resource`, and MCP scopes are not forwarded to Lightdash. They belong to a different OAuth leg and have different semantics.
+- Lightdash user identity and RBAC continue to be validated/enforced with the delegated downstream credential.
+- A Lightdash `refresh_token`, if returned, is not persisted or exposed; expiration requires a new interactive authorization flow.
+
+### Statelessness
+
+The authorization/DCR/code handshake continues to use the bounded in-memory broker store, so `/oauth/*` requires sticky routing or a single replica while that handshake is in flight.
+
+After `/oauth/token` succeeds, MCP access tokens are self-contained and authenticated-encrypted. Normal profile MCP requests therefore remain stateless and can be served by any replica sharing the same configured OAuth client secret.
+
+## Consequences
+
+### Positive
+
+- An MCP client never receives a reusable Lightdash bearer credential.
+- Lightdash tokens cannot be presented directly as MCP access tokens.
+- MCP tokens have an explicit, cryptographically protected audience at profile-path granularity.
+- Cross-profile token replay is rejected before contacting Lightdash.
+- MCP scope and downstream Lightdash scope cannot be confused.
+- The fix preserves stateless profile request handling and does not reintroduce Redis.
+- Key distribution does not require another deployment secret because replicas already share the Lightdash confidential-client secret; key derivation is domain-separated from its OAuth use.
+
+### Negative / residual risks
+
+- Self-contained bearer tokens do not provide per-token server-side revocation. They stop working on expiry, downstream credential revocation, or OAuth client-secret rotation. A future shared opaque-token store could add fine-grained MCP revocation if required.
+- Compromise of the MCP server process or its OAuth client secret can expose/decrypt delegated Lightdash credentials. This is inherent in the server-side delegation role and reinforces the need for secret-manager-backed configuration, least privilege, audit logging, and short token lifetimes.
+- The in-memory DCR/authorization-code handshake is still process-local. This ADR deliberately does not introduce a distributed authorization state store.
+- This decision separates token audiences; it does not by itself implement every MCP proxy-server control such as a richer per-client consent UI. Those controls are evaluated independently.
+
+## References
+
+- MCP Authorization specification (2026-07-28): https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization
+- MCP Security Best Practices — Token Passthrough: https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices
+- RFC 8707 — Resource Indicators for OAuth 2.0: https://www.rfc-editor.org/rfc/rfc8707
+- ADR-0007 — MCP HTTP transport, OAuth broker, SDK v2
+- ADR-0019 — MCP stateless protocol core without Redis ephemeral store

--- a/docs/adr/0026-mcp-oauth-dual-leg-token-boundary.md
+++ b/docs/adr/0026-mcp-oauth-dual-leg-token-boundary.md
@@ -85,8 +85,8 @@ After `/oauth/token` succeeds, MCP access tokens are self-contained and authenti
 
 ## References
 
-- MCP Authorization specification (2026-07-28): https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization
-- MCP Security Best Practices — Token Passthrough: https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices
-- RFC 8707 — Resource Indicators for OAuth 2.0: https://www.rfc-editor.org/rfc/rfc8707
+- [MCP Authorization specification (2026-07-28)](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
+- [MCP Security Best Practices — Token Passthrough](https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices)
+- [RFC 8707 — Resource Indicators for OAuth 2.0](https://www.rfc-editor.org/rfc/rfc8707)
 - ADR-0007 — MCP HTTP transport, OAuth broker, SDK v2
 - ADR-0019 — MCP stateless protocol core without Redis ephemeral store

--- a/docs/adr/0026-mcp-oauth-dual-leg-token-boundary.md
+++ b/docs/adr/0026-mcp-oauth-dual-leg-token-boundary.md
@@ -43,17 +43,17 @@ Lightdash API
 - The MCP authorization request MUST contain exactly one `resource` identifying an enabled profile endpoint on the configured MCP public URL.
 - The broker binds that resource to its pending authorization state and one-time authorization code.
 - The MCP token request MUST contain the same `resource`; a mismatch fails with `invalid_grant`.
-- The broker MUST NOT return the downstream Lightdash access token to the MCP client.
+- The broker MUST NOT return the downstream Lightdash access token to the MCP client in plaintext or reusable bearer form.
 - `/oauth/token` mints a short-lived `ldmcp1.*` bearer token issued by lightdash-tools.
 - The token is authenticated-encrypted with AES-256-GCM. A purpose-specific encryption key is derived from the server-held Lightdash OAuth client secret; every replica already needs that secret.
-- The encrypted payload binds the MCP client ID, exact MCP resource URI, MCP scope, issuance/expiry timestamps, and the server-held downstream credential.
+- The encrypted payload binds the MCP client ID, exact MCP resource URI, MCP scope, issuance/expiry timestamps, and the downstream Lightdash credential. Only the MCP server can recover that credential from the broker token.
 - The MCP resource server decrypts and authenticates the token and requires an exact resource match before any Lightdash network request.
 - Raw Lightdash bearer tokens, malformed tokens, expired tokens, tampered tokens, and tokens issued for another profile are rejected locally with HTTP 401.
 
 ### Broker -> Lightdash leg
 
 - The server-held Lightdash OAuth client ID/secret are used for the downstream authorization-code exchange.
-- The resulting Lightdash access token remains server-side.
+- The resulting Lightdash access token is never returned to the MCP client in plaintext or directly reusable form; it is recoverable only server-side from the authenticated-encrypted broker token.
 - Client PKCE, MCP `resource`, and MCP scopes are not forwarded to Lightdash. They belong to a different OAuth leg and have different semantics.
 - Lightdash user identity and RBAC continue to be validated/enforced with the delegated downstream credential.
 - A Lightdash `refresh_token`, if returned, is not persisted or exposed; expiration requires a new interactive authorization flow.

--- a/docs/adr/0026-mcp-oauth-dual-leg-token-boundary.md
+++ b/docs/adr/0026-mcp-oauth-dual-leg-token-boundary.md
@@ -6,6 +6,8 @@ Date: 2026-08-17
 
 Accepted
 
+Amends [7. MCP HTTP transport, OAuth broker, SDK v2](0007-mcp-http-transport-auth-modes-sdk-v2.md)
+
 ## Context
 
 The hosted HTTP MCP server is both:
@@ -74,19 +76,20 @@ After `/oauth/token` succeeds, MCP access tokens are self-contained and authenti
 - Cross-profile token replay is rejected before contacting Lightdash.
 - MCP scope and downstream Lightdash scope cannot be confused.
 - The fix preserves stateless profile request handling and does not reintroduce Redis.
-- Key distribution does not require another deployment secret because replicas already share the Lightdash confidential-client secret; key derivation is domain-separated from its OAuth use.
+- Key distribution does not require another deployment secret because replicas already share the Lightdash confidential-client secret; key derivation is domain-separated from its OAuth use. That coupling is **accepted for v1**.
 
 ### Negative / residual risks
 
 - Self-contained bearer tokens do not provide per-token server-side revocation. They stop working on expiry, downstream credential revocation, or OAuth client-secret rotation. A future shared opaque-token store could add fine-grained MCP revocation if required.
-- Compromise of the MCP server process or its OAuth client secret can expose/decrypt delegated Lightdash credentials. This is inherent in the server-side delegation role and reinforces the need for secret-manager-backed configuration, least privilege, audit logging, and short token lifetimes.
+- Compromise of the MCP server process or its OAuth client secret can expose/decrypt delegated Lightdash credentials (and all outstanding MCP tokens). This is inherent in the server-side delegation role and reinforces the need for secret-manager-backed configuration, least privilege, audit logging, and short token lifetimes. A dedicated MCP token encryption secret (separate from the Lightdash OAuth client secret) would reduce blast radius and should be introduced by a future superseding ADR if operators need independent rotation.
+- MCP scopes sealed into the broker token are still taken from the client authorize request and checked against configured `requiredScopes`; they are not yet a broker-owned grant/consent boundary. Scope minimization and step-up remain future work.
 - The in-memory DCR/authorization-code handshake is still process-local. This ADR deliberately does not introduce a distributed authorization state store.
-- This decision separates token audiences; it does not by itself implement every MCP proxy-server control such as a richer per-client consent UI. Those controls are evaluated independently.
+- This decision closes token passthrough and MCP audience binding. It does **not** implement MCP proxy per-client consent before the static Lightdash OAuth redirect (confused-deputy class). That control is evaluated independently.
 
 ## References
 
 - [MCP Authorization specification (2026-07-28)](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
-- [MCP Security Best Practices — Token Passthrough](https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices)
+- [MCP Security Best Practices — Token Passthrough / Confused Deputy](https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices)
 - [RFC 8707 — Resource Indicators for OAuth 2.0](https://www.rfc-editor.org/rfc/rfc8707)
-- ADR-0007 — MCP HTTP transport, OAuth broker, SDK v2
-- ADR-0019 — MCP stateless protocol core without Redis ephemeral store
+- [7. MCP HTTP transport, OAuth broker, SDK v2](0007-mcp-http-transport-auth-modes-sdk-v2.md)
+- [19. MCP stateless protocol core without Redis ephemeral store](0019-mcp-stateless-protocol-core-without-redis-ephemeral-store.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,5 +45,6 @@ Vocabulary: living product term is **profile**. The MCP protocol uses Host / Cli
 22. [Request-scoped MCP operation notifications](0023-request-scoped-mcp-operation-notifications.md)
 23. [MCP HTTP profile mount allowlist via env](0024-mcp-http-profile-mount-allowlist-via-env.md)
 24. [MCP progressive-disclosure prompt context policies](0025-mcp-progressive-disclosure-prompt-context-policies.md)
+25. [MCP OAuth uses a dual-leg, resource-bound token boundary](0026-mcp-oauth-dual-leg-token-boundary.md)
 
 Number **16** is unused in the binding set (former pluggable Redis/ephemeral store; superseded by 0019).

--- a/docs/operators/mcp-oauth-threat-model.md
+++ b/docs/operators/mcp-oauth-threat-model.md
@@ -1,34 +1,37 @@
 # Threat model: OAuth-backed Streamable HTTP MCP
 
-Security analysis for hosted `@lightdash-tools/mcp` with the **OAuth broker** (server-held Lightdash confidential client). Architecture: [ADR-0007](../adr/0007-mcp-http-transport-auth-modes-sdk-v2.md). Protocol: [MCP Authorization 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization).
+Security analysis for hosted `@lightdash-tools/mcp` with the **dual-leg OAuth broker** (server-held Lightdash confidential client + broker-issued MCP access tokens). Architecture: [ADR-0007](../adr/0007-mcp-http-transport-auth-modes-sdk-v2.md) as amended by [ADR-0026](../adr/0026-mcp-oauth-dual-leg-token-boundary.md). Protocol: [MCP Authorization 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization). Security guidance: [MCP Security Best Practices](https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices).
 
 ## Assets
 
 | Asset                           | Protection need                                                                                                                                                      |
 | :------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Lightdash OAuth client secret   | Server-only; never in MCP client config or logs.                                                                                                                     |
-| Lightdash OAuth access token    | Must never be logged or persisted by default.                                                                                                                        |
+| Lightdash OAuth client secret   | Server-only; never in MCP client config or logs. Also derives the v1 MCP token AEAD key ([ADR-0026](../adr/0026-mcp-oauth-dual-leg-token-boundary.md)).              |
+| Broker-issued MCP access token  | Audience-bound `ldmcp1.*` bearer; must not be logged in plaintext; theft allows MCP use until expiry.                                                                |
+| Lightdash OAuth access token    | Must never be returned to MCP clients as a reusable bearer; recoverable only server-side from a valid broker token. Never logged or persisted by default.            |
 | Lightdash data and tool results | Must be scoped by Lightdash permissions, profile tool surface (catalog membership), optional HTTP project pin, and optional `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS`. |
 | MCP endpoint                    | Must not expose tools unauthenticated in production.                                                                                                                 |
-| Session / broker pending state  | Must not allow user or token confusion across sessions.                                                                                                              |
+| Broker pending / DCR / codes    | Process-local; must not allow user or token confusion across pending authorizations.                                                                                 |
 | Audit logs                      | Must not leak credentials or unnecessary sensitive raw data.                                                                                                         |
 
 ## Threats and mitigations
 
-| Threat                                     | Risk   | Mitigation                                                                                                                                                                                                                                                                                             |
-| :----------------------------------------- | :----- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Public unauthenticated MCP endpoint        | High   | Production requires OAuth client credentials + `PUBLIC_URL`, or shared-key+PAT. Unauthenticated HTTP rejected unless `NODE_ENV` is not `production` (e.g. local Compose).                                                                                                                              |
-| Client secret leakage to MCP clients       | High   | Secret stays on MCP process; clients use URL-only config. Broker is confidential client to Lightdash.                                                                                                                                                                                                  |
-| Open redirect / confused deputy on broker  | High   | Bind pending auth to client `redirect_uri` + PKCE + `resource`; Lightdash always sees fixed `{PUBLIC_URL}/oauth/callback` only.                                                                                                                                                                        |
-| Shared PAT overreach                       | High   | PAT/shared-key is secondary; prefer OAuth. Profile tool surface (catalog membership) + Lightdash RBAC (+ optional `X-Lightdash-Project` pin and/or `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS`).                                                                                                           |
-| Token replay / audience gap                | High   | Identity validation via `GET /api/v1/user` only until upstream resource-bound tokens. Restrict ingress; one Lightdash OAuth app per deployment.                                                                                                                                                        |
-| Token leakage in logs                      | High   | Redact `Authorization` in reverse proxies and platform logs. Never log raw tokens or client secret. Audit entries use token hash only.                                                                                                                                                                 |
-| Token/session confusion                    | High   | Bind sessions to `userUuid` and `organizationUuid`; reject subject or organization mismatch on resume.                                                                                                                                                                                                 |
-| OAuth metadata spoofing (wrong public URL) | Medium | Require `LIGHTDASH_TOOLS_MCP_PUBLIC_URL`. Normalize URL. PRM `authorization_servers` = public MCP host (broker), not Lightdash directly.                                                                                                                                                               |
-| Reimplemented RBAC mismatch                | High   | Do not recreate Lightdash object-level permissions in MCP. Delegate to Lightdash API with the user's bearer token.                                                                                                                                                                                     |
-| Agent destructive actions                  | High   | Profile `tools` mounts fix the MCP catalog (ADR-0006 / ADR-0022; [ADR-0008](../adr/0008-mcp-request-scope-and-hardening.md)); shipped `semantic-layer` profile is discovery/compile only; irrecoverable ops are client-only per [ADR-0004](../adr/0004-agent-safe-exposure-mcp-cli-vs-client-only.md). |
-| CSRF / browser-origin misuse               | Medium | Bearer tokens in `Authorization` header only. Optional `LIGHTDASH_TOOLS_MCP_ALLOWED_ORIGINS`. No cookie-based MCP auth.                                                                                                                                                                                |
-| Rate-limit bypass / session exhaustion     | Medium | Per-subject and global in-memory session caps. Use gateway rate limits in production; keep session TTLs short.                                                                                                                                                                                         |
+| Threat                                          | Risk   | Mitigation                                                                                                                                                                                                                                                                                             |
+| :---------------------------------------------- | :----- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Public unauthenticated MCP endpoint             | High   | Production requires OAuth client credentials + `PUBLIC_URL`, or shared-key+PAT. Unauthenticated HTTP rejected unless `NODE_ENV` is not `production` (e.g. local Compose).                                                                                                                              |
+| Client secret leakage to MCP clients            | High   | Secret stays on MCP process; clients use URL-only config. Broker is confidential client to Lightdash.                                                                                                                                                                                                  |
+| Token passthrough / MCP audience gap            | High   | **Mitigated ([ADR-0026](../adr/0026-mcp-oauth-dual-leg-token-boundary.md))**: broker mints resource-bound `ldmcp1.*` tokens; RS rejects raw Lightdash bearers, wrong-profile tokens, tampered/expired tokens before any Lightdash call. Downstream credential is recovered only after local verify.    |
+| Confused deputy (static Lightdash client + DCR) | High   | **Open**: redirect_uri + PKCE + `resource` binding and fixed `{PUBLIC_URL}/oauth/callback` reduce some abuse, but MCP Security Best Practices still require per-client consent before forwarding to the third-party AS. Not implemented in this release.                                               |
+| Shared PAT overreach                            | High   | PAT/shared-key is secondary; prefer OAuth. Profile tool surface (catalog membership) + Lightdash RBAC (+ optional `X-Lightdash-Project` pin and/or `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS`).                                                                                                           |
+| AEAD key / client-secret compromise             | High   | Compromise of `LIGHTDASH_TOOLS_OAUTH_CLIENT_SECRET` can decrypt outstanding MCP tokens (each carries a delegated Lightdash credential). Inject from a secret manager; rotate invalidates all MCP sessions; future dedicated MCP token key is a follow-up.                                              |
+| No per-token MCP revocation                     | Medium | Self-contained broker tokens stop on expiry, upstream Lightdash revocation, or OAuth client-secret rotation. Opaque shared token store is out of scope (conflicts with ADR-0019 unless product requires revoke).                                                                                       |
+| Token leakage in logs                           | High   | Redact `Authorization` in reverse proxies and platform logs. Never log raw tokens or client secret. Audit entries use token hash only.                                                                                                                                                                 |
+| Token/session confusion                         | High   | Bind sessions to `userUuid` and `organizationUuid`; reject subject or organization mismatch on resume.                                                                                                                                                                                                 |
+| OAuth metadata spoofing (wrong public URL)      | Medium | Require `LIGHTDASH_TOOLS_MCP_PUBLIC_URL`. Normalize URL. PRM `authorization_servers` = public MCP host (broker), not Lightdash directly.                                                                                                                                                               |
+| Reimplemented RBAC mismatch                     | High   | Do not recreate Lightdash object-level permissions in MCP. Delegate to Lightdash API with the recovered downstream credential after broker-token validation.                                                                                                                                           |
+| Agent destructive actions                       | High   | Profile `tools` mounts fix the MCP catalog (ADR-0006 / ADR-0022; [ADR-0008](../adr/0008-mcp-request-scope-and-hardening.md)); shipped `semantic-layer` profile is discovery/compile only; irrecoverable ops are client-only per [ADR-0004](../adr/0004-agent-safe-exposure-mcp-cli-vs-client-only.md). |
+| CSRF / browser-origin misuse                    | Medium | Bearer tokens in `Authorization` header only. Optional `LIGHTDASH_TOOLS_MCP_ALLOWED_ORIGINS`. No cookie-based MCP auth.                                                                                                                                                                                |
+| Rate-limit bypass / pending-store exhaustion    | Medium | Bounded in-memory broker pending/DCR/code caps. Use gateway rate limits in production; keep pending TTLs short. Sticky `/oauth/*` or single replica while handshake is in flight.                                                                                                                      |
 
 ## Operator security checklist
 
@@ -41,11 +44,13 @@ Security analysis for hosted `@lightdash-tools/mcp` with the **OAuth broker** (s
 - [ ] On Cloud Run / hosted HTTP: leave `LIGHTDASH_TOOLS_AUDIT_LOG` **unset** so tool audits go to stderr → Cloud Logging (`jsonPayload.channel="audit"`). Use a file path only for CLI/local. See [cloud-run.md](cloud-run.md).
 - [ ] Do **not** set `LIGHTDASH_API_KEY` for primary OAuth hosting (PAT is secondary / stdio / shared-key).
 - [ ] Do not rely on `LIGHTDASH_TOOLS_SAFETY_MODE` / `DRY_RUN` for MCP — those are CLI-only (`LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS` is shared with MCP as the project ceiling).
+- [ ] After upgrade to dual-leg tokens: force MCP clients to re-authenticate (cached raw Lightdash bearers are rejected).
 
 ### Secrets handling
 
 - [ ] Inject env vars from the platform (Cloud Run secrets, Kubernetes, systemd) — not plaintext `.env` on disk.
 - [ ] Keep OAuth **client secret on the MCP server** only — never in Cursor/Claude `mcp.json`.
+- [ ] Treat client-secret rotation as a mass MCP re-auth event (v1 AEAD key is derived from that secret).
 - [ ] See [secrets.md](secrets.md).
 
 ### Logging and observability
@@ -60,26 +65,32 @@ Security analysis for hosted `@lightdash-tools/mcp` with the **OAuth broker** (s
 
 - [ ] Terminate TLS at the platform edge (Cloud Run, load balancer).
 - [ ] Restrict ingress where possible (private service connect, allowlisted clients).
-- [ ] Document single-instance or sticky-session requirement for in-memory sessions and broker pending auth (v1).
-- [ ] Plan external session store (Redis) before horizontal scale without affinity.
+- [ ] Sticky-route `/oauth/*` (or single replica) for in-memory broker pending/DCR/code handshake; profile MCP paths may be load-balanced after token issuance ([ADR-0019](../adr/0019-mcp-stateless-protocol-core-without-redis-ephemeral-store.md) / [ADR-0026](../adr/0026-mcp-oauth-dual-leg-token-boundary.md)).
+- [ ] Do not reintroduce Redis solely for OAuth pending state unless a later ADR supersedes ADR-0019.
 
 ### Client configuration
 
 - [ ] Point Claude Code / Cursor at `https://{host}/semantic-layer/v1/mcp` only (no client secret).
+- [ ] After dual-leg deploy, re-run OAuth so clients hold `ldmcp1.*` tokens rather than raw Lightdash bearers.
 - [ ] Validate identity after setup (e.g. a read tool that hits Lightdash as the user).
 
 ## Out of scope (v1 non-goals)
 
 - Full RFC 7591 DCR product (thin stub only if clients require `/register`)
+- Client ID Metadata Documents (CIMD) as the primary registration path
 - Refresh token persistence DB / Redis
 - `@modelcontextprotocol/server-legacy` AS router
 - MCP auth extensions (client-credentials, enterprise-managed)
 - CLI process safety mode / allowlist / dry-run on MCP (profile-first; ADR-0008)
-- Full RFC 8707 audience enforcement when Lightdash tokens remain opaque
+- Per-client consent UI before the static Lightdash OAuth redirect (confused-deputy follow-up)
+- Dedicated MCP token encryption secret separate from the Lightdash OAuth client secret
+- Independent MCP max TTL cap beyond upstream Lightdash `expires_in`
+- Opaque / shared MCP access-token store for fine-grained revocation
 
 ## Related documentation
 
 - [mcp-oauth.md](mcp-oauth.md) — setup and troubleshooting
+- [ADR-0026](../adr/0026-mcp-oauth-dual-leg-token-boundary.md) — dual-leg token boundary
 - [cursor-claude.md](cursor-claude.md) — Cursor client setup
 - [cloud-run.md](cloud-run.md) — Cloud Run deployment
 - [agent-context.md](agent-context.md) — agent guardrail invariants

--- a/docs/operators/mcp-oauth.md
+++ b/docs/operators/mcp-oauth.md
@@ -1,29 +1,53 @@
 # OAuth-backed Streamable HTTP MCP
 
-Operator guide for hosted `@lightdash-tools/mcp` with a **server-held Lightdash OAuth application** (confidential client + broker). Architecture: [ADR-0007](../adr/0007-mcp-http-transport-auth-modes-sdk-v2.md). Protocol: [MCP Authorization 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization). Threat model: [mcp-oauth-threat-model.md](mcp-oauth-threat-model.md).
+Operator guide for hosted `@lightdash-tools/mcp` with a **server-held Lightdash OAuth application** (confidential client + dual-leg broker). Architecture: [ADR-0007](../adr/0007-mcp-http-transport-auth-modes-sdk-v2.md) as amended by [ADR-0026](../adr/0026-mcp-oauth-dual-leg-token-boundary.md). Protocol: [MCP Authorization 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization). Threat model: [mcp-oauth-threat-model.md](mcp-oauth-threat-model.md).
 
 ## Mental model
 
-| Role                                   | Who                                                               |
-| :------------------------------------- | :---------------------------------------------------------------- |
-| Lightdash OAuth app (client id/secret) | **MCP server** env                                                |
-| Redirect URI (one, shared)             | `{PUBLIC_URL}/oauth/callback`                                     |
-| AS façade for MCP clients              | MCP host (`/oauth/*`, PRM `authorization_servers` = `PUBLIC_URL`) |
-| Resource servers                       | Profile paths (`/semantic-layer/v1/mcp`, …)                       |
-| MCP clients (Claude Code / Cursor)     | **URL only** — no client secret                                   |
+| Role                                   | Who                                                                                       |
+| :------------------------------------- | :---------------------------------------------------------------------------------------- |
+| Lightdash OAuth app (client id/secret) | **MCP server** env (downstream confidential client)                                       |
+| Redirect URI (one, shared)             | `{PUBLIC_URL}/oauth/callback`                                                             |
+| AS façade for MCP clients              | MCP host (`/oauth/*`, PRM `authorization_servers` = `PUBLIC_URL`)                         |
+| MCP access token                       | Broker-issued `ldmcp1.*` AEAD bearer; audience = exact enabled profile resource           |
+| Downstream Lightdash credential        | Recovered server-side from the broker token only; never returned as the MCP client bearer |
+| Resource servers                       | Profile paths (`/semantic-layer/v1/mcp`, …)                                               |
+| MCP clients (Claude Code / Cursor)     | **URL only** — no client secret                                                           |
 
 Auth mode is **inferred** from credentials (no `LIGHTDASH_TOOLS_MCP_AUTH_MODE`).
 
+```text
+MCP client
+    |
+    | broker-issued MCP token (audience = exact profile resource)
+    v
+lightdash-tools MCP server
+    |
+    | decrypt + validate broker token
+    | recover delegated Lightdash credential
+    v
+Lightdash API
+```
+
 ## Limitations (honest)
 
-| Capability                                                    | Status                                        |
-| :------------------------------------------------------------ | :-------------------------------------------- |
-| Per-user bearer to Lightdash                                  | Supported                                     |
-| Server-held confidential client + shared callback             | Supported                                     |
-| PRM + broker AS metadata                                      | Supported                                     |
-| Full RFC 8707 audience enforcement on opaque Lightdash tokens | **Limited** — identity via `GET /api/v1/user` |
+| Capability                                                        | Status                                                                                                                             |
+| :---------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------- |
+| Per-user delegated access to Lightdash                            | Supported                                                                                                                          |
+| Server-held confidential client + shared callback                 | Supported                                                                                                                          |
+| PRM + broker AS metadata                                          | Supported                                                                                                                          |
+| RFC 8707 MCP resource / audience binding                          | Supported — broker-issued `ldmcp1.*` bound to exact profile resource                                                               |
+| Reject raw Lightdash bearers as MCP credentials                   | Supported                                                                                                                          |
+| Sticky `/oauth/*` (or single replica) during authorize→token      | Required — in-memory pending/DCR/code store ([ADR-0019](../adr/0019-mcp-stateless-protocol-core-without-redis-ephemeral-store.md)) |
+| Stateless profile MCP requests after token issuance               | Supported — any replica sharing the OAuth client secret                                                                            |
+| Per-client consent UI before Lightdash redirect (confused deputy) | **Not implemented** — see threat model                                                                                             |
+| Per-token MCP revocation store                                    | **Not implemented** — expiry / client-secret rotation / upstream revoke                                                            |
 
 Authorization in practice: Lightdash RBAC + profile `tools` mounts (ADR-0006 / ADR-0022) + optional `X-Lightdash-Project` pin and/or `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS` ([ADR-0008](../adr/0008-mcp-request-scope-and-hardening.md)).
+
+### Breaking change
+
+Deployments that previously accepted a raw Lightdash access token as the MCP `Authorization: Bearer` value will reject those tokens after upgrade. Existing MCP clients must complete the OAuth flow again so they receive a broker-issued `ldmcp1.*` token.
 
 ## Primary: hosted OAuth
 
@@ -39,6 +63,7 @@ npx @lightdash-tools/mcp http
 1. Create a Lightdash OAuth application.
 2. Register redirect URI exactly: `https://lightdash-mcp.example.com/oauth/callback`.
 3. Put client id/secret on the **MCP server** (Secret Manager / platform env), never in client `mcp.json`.
+4. For multi-replica hosting: sticky-route `/oauth/*` (or run one broker replica); profile MCP paths may load-balance.
 
 Verify:
 
@@ -81,20 +106,22 @@ URL only:
 
 Do **not** put `LIGHTDASH_TOOLS_OAUTH_CLIENT_*` in the client. See [cursor-claude.md](cursor-claude.md).
 
+After deploying the dual-leg broker, re-run the client OAuth login so cached raw Lightdash tokens are replaced with `ldmcp1.*` broker tokens.
+
 ## Environment reference
 
-| Variable                              | Role                                                                     |
-| :------------------------------------ | :----------------------------------------------------------------------- |
-| `LIGHTDASH_URL`                       | Lightdash instance                                                       |
-| `LIGHTDASH_TOOLS_MCP_PUBLIC_URL`      | Public base URL (required for OAuth)                                     |
-| `LIGHTDASH_TOOLS_OAUTH_CLIENT_ID`     | Server-held Lightdash app client id                                      |
-| `LIGHTDASH_TOOLS_OAUTH_CLIENT_SECRET` | Server-held Lightdash app client secret                                  |
-| `LIGHTDASH_TOOLS_MCP_SHARED_KEY`      | Secondary shared-key gateway                                             |
-| `LIGHTDASH_API_KEY`                   | Stdio / shared-key / local none upstream PAT                             |
-| `LIGHTDASH_TOOLS_MCP_ALLOWED_ORIGINS` | Optional CORS allowlist                                                  |
-| `LIGHTDASH_TOOLS_AUDIT_LOG`           | Optional file path (CLI/local); unset → stderr JSON audit                |
-| `LIGHTDASH_TOOLS_MCP_HTTP_PORT`       | Default `3100`; if unset, platform `PORT` (e.g. Cloud Run), else `3100`  |
-| `LIGHTDASH_TOOLS_MCP_PROFILES`        | Optional HTTP mount allowlist (comma-separated profile ids; unset = all) |
+| Variable                              | Role                                                                      |
+| :------------------------------------ | :------------------------------------------------------------------------ |
+| `LIGHTDASH_URL`                       | Lightdash instance                                                        |
+| `LIGHTDASH_TOOLS_MCP_PUBLIC_URL`      | Public base URL (required for OAuth)                                      |
+| `LIGHTDASH_TOOLS_OAUTH_CLIENT_ID`     | Server-held Lightdash app client id                                       |
+| `LIGHTDASH_TOOLS_OAUTH_CLIENT_SECRET` | Server-held Lightdash app client secret (also derives MCP token AEAD key) |
+| `LIGHTDASH_TOOLS_MCP_SHARED_KEY`      | Secondary shared-key gateway                                              |
+| `LIGHTDASH_API_KEY`                   | Stdio / shared-key / local none upstream PAT                              |
+| `LIGHTDASH_TOOLS_MCP_ALLOWED_ORIGINS` | Optional CORS allowlist                                                   |
+| `LIGHTDASH_TOOLS_AUDIT_LOG`           | Optional file path (CLI/local); unset → stderr JSON audit                 |
+| `LIGHTDASH_TOOLS_MCP_HTTP_PORT`       | Default `3100`; if unset, platform `PORT` (e.g. Cloud Run), else `3100`   |
+| `LIGHTDASH_TOOLS_MCP_PROFILES`        | Optional HTTP mount allowlist (comma-separated profile ids; unset = all)  |
 
 **Rejected at startup** (removed): `LIGHTDASH_TOOLS_MCP_AUTH_MODE`, `EXPERIMENTAL_IDENTITY_OAUTH`, `DANGEROUSLY_*`, `ALLOW_INSECURE_PUBLIC_URL`, `LIGHTDASH_TOOLS_MCP_INSECURE_DEV`, `LIGHTDASH_TOOLS_MCP_PATH`.
 
@@ -102,18 +129,19 @@ CLI-only (ignored for MCP auth): `LIGHTDASH_TOOLS_SAFETY_MODE`, `DRY_RUN`. Share
 
 ## Broker routes
 
-| Path                                      | Purpose                                                                      |
-| :---------------------------------------- | :--------------------------------------------------------------------------- |
-| `/oauth/authorize`                        | Start client OAuth; redirect to Lightdash with fixed callback                |
-| `/oauth/callback`                         | Lightdash redirect; exchange code with client secret                         |
-| `/oauth/token`                            | Client token exchange (PKCE)                                                 |
-| `/oauth/register`                         | Thin DCR stub (public client)                                                |
-| `/.well-known/oauth-authorization-server` | Broker AS metadata                                                           |
-| `/.well-known/oauth-protected-resource`   | PRM (`authorization_servers` = `PUBLIC_URL`)                                 |
-| `/health/live`, `/health/ready`           | Unauthenticated process probes (not OAuth; see [cloud-run.md](cloud-run.md)) |
+| Path                                      | Purpose                                                                           |
+| :---------------------------------------- | :-------------------------------------------------------------------------------- |
+| `/oauth/authorize`                        | Start client OAuth; require `resource`; redirect to Lightdash with fixed callback |
+| `/oauth/callback`                         | Lightdash redirect; exchange code with client secret                              |
+| `/oauth/token`                            | PKCE + same `resource`; mint `ldmcp1.*` MCP access token                          |
+| `/oauth/register`                         | Thin DCR stub (public client)                                                     |
+| `/.well-known/oauth-authorization-server` | Broker AS metadata                                                                |
+| `/.well-known/oauth-protected-resource`   | PRM (`authorization_servers` = `PUBLIC_URL`)                                      |
+| `/health/live`, `/health/ready`           | Unauthenticated process probes (not OAuth; see [cloud-run.md](cloud-run.md))      |
 
 ## Related
 
+- [ADR-0026 — dual-leg MCP OAuth token boundary](../adr/0026-mcp-oauth-dual-leg-token-boundary.md)
 - [cursor-claude.md](cursor-claude.md)
 - [cloud-run.md](cloud-run.md)
 - [mcp-oauth-threat-model.md](mcp-oauth-threat-model.md)

--- a/packages/mcp/src/auth/oauth-broker/lightdash-token.ts
+++ b/packages/mcp/src/auth/oauth-broker/lightdash-token.ts
@@ -72,16 +72,17 @@ export async function exchangeLightdashAuthorizationCode(
 }
 
 /**
- * Builds the Lightdash authorize URL for the server-held confidential client.
- * Client PKCE is enforced between MCP client and broker only — do not forward
- * the client's code_challenge upstream (token exchange uses client_secret).
+ * Builds the downstream Lightdash authorize URL for the server-held confidential client.
+ *
+ * Client PKCE, MCP scopes, and RFC 8707 `resource` are properties of the MCP client→broker
+ * authorization leg. They must not be forwarded blindly to Lightdash: the downstream
+ * authorization leg has a different client and protected resource. The broker state is the
+ * only client-flow correlation value propagated upstream.
  */
 export function buildLightdashAuthorizeUrl(
   config: McpHttpConfig,
   params: {
     state: string;
-    scope?: string;
-    resource?: string;
   },
 ): string {
   if (!config.oauthClientId) {
@@ -93,12 +94,5 @@ export function buildLightdashAuthorizeUrl(
   url.searchParams.set('client_id', config.oauthClientId);
   url.searchParams.set('redirect_uri', getOAuthCallbackUrl(config));
   url.searchParams.set('state', params.state);
-  if (params.scope) {
-    url.searchParams.set('scope', params.scope);
-  }
-  // Forward resource when Lightdash supports RFC 8707; harmless if ignored.
-  if (params.resource) {
-    url.searchParams.set('resource', params.resource);
-  }
   return url.toString();
 }

--- a/packages/mcp/src/auth/oauth-broker/mcp-access-token.test.ts
+++ b/packages/mcp/src/auth/oauth-broker/mcp-access-token.test.ts
@@ -66,7 +66,13 @@ describe('MCP broker access token', () => {
       NOW,
     );
 
-    const tampered = `${accessToken.slice(0, -1)}${accessToken.endsWith('A') ? 'B' : 'A'}`;
+    // Mutate the first Base64URL character of the authentication-tag segment. Changing
+    // the final character can alter only unused padding bits and still decode to identical bytes.
+    const parts = accessToken.split('.');
+    const tag = parts[3]!;
+    parts[3] = `${tag[0] === 'A' ? 'B' : 'A'}${tag.slice(1)}`;
+    const tampered = parts.join('.');
+
     expect(verifyMcpAccessToken(config, tampered, RESOURCE, NOW)).toBeUndefined();
     expect(verifyMcpAccessToken(config, accessToken, RESOURCE, NOW + 2_000)).toBeUndefined();
   });

--- a/packages/mcp/src/auth/oauth-broker/mcp-access-token.test.ts
+++ b/packages/mcp/src/auth/oauth-broker/mcp-access-token.test.ts
@@ -1,0 +1,77 @@
+import { SecretString } from '@lightdash-tools/client';
+import { describe, expect, it } from 'vitest';
+
+import { makeTestMcpHttpConfig } from '../../config/test-mcp-http-config.js';
+
+import { mintMcpAccessToken, verifyMcpAccessToken } from './mcp-access-token.js';
+
+const config = makeTestMcpHttpConfig({
+  oauthClientId: 'ld-client',
+  oauthClientSecret: new SecretString('test-lightdash-confidential-client-secret'),
+});
+
+const RESOURCE = 'https://mcp.example.com/semantic-layer/v1/mcp';
+const OTHER_RESOURCE = 'https://mcp.example.com/content-governance/v1/mcp';
+const NOW = 1_800_000_000_000;
+
+describe('MCP broker access token', () => {
+  it('round-trips a downstream credential without exposing it as the bearer token', () => {
+    const minted = mintMcpAccessToken(
+      config,
+      {
+        lightdashAccessToken: 'ld-upstream-secret',
+        clientId: 'mcp-client-1',
+        resource: RESOURCE,
+        scope: 'mcp:read',
+        expiresAtMs: NOW + 60_000,
+      },
+      NOW,
+    );
+
+    expect(minted.accessToken).toMatch(/^ldmcp1\./);
+    expect(minted.accessToken).not.toContain('ld-upstream-secret');
+    expect(minted.expiresIn).toBe(60);
+    expect(verifyMcpAccessToken(config, minted.accessToken, RESOURCE, NOW)).toMatchObject({
+      lightdashAccessToken: 'ld-upstream-secret',
+      clientId: 'mcp-client-1',
+      resource: RESOURCE,
+      scope: 'mcp:read',
+    });
+  });
+
+  it('rejects a token at a different MCP protected resource', () => {
+    const { accessToken } = mintMcpAccessToken(
+      config,
+      {
+        lightdashAccessToken: 'ld-upstream-secret',
+        clientId: 'mcp-client-1',
+        resource: RESOURCE,
+        expiresAtMs: NOW + 60_000,
+      },
+      NOW,
+    );
+
+    expect(verifyMcpAccessToken(config, accessToken, OTHER_RESOURCE, NOW)).toBeUndefined();
+  });
+
+  it('rejects tampered and expired tokens', () => {
+    const { accessToken } = mintMcpAccessToken(
+      config,
+      {
+        lightdashAccessToken: 'ld-upstream-secret',
+        clientId: 'mcp-client-1',
+        resource: RESOURCE,
+        expiresAtMs: NOW + 1_000,
+      },
+      NOW,
+    );
+
+    const tampered = `${accessToken.slice(0, -1)}${accessToken.endsWith('A') ? 'B' : 'A'}`;
+    expect(verifyMcpAccessToken(config, tampered, RESOURCE, NOW)).toBeUndefined();
+    expect(verifyMcpAccessToken(config, accessToken, RESOURCE, NOW + 2_000)).toBeUndefined();
+  });
+
+  it('rejects raw downstream Lightdash access tokens', () => {
+    expect(verifyMcpAccessToken(config, 'ld-upstream-secret', RESOURCE, NOW)).toBeUndefined();
+  });
+});

--- a/packages/mcp/src/auth/oauth-broker/mcp-access-token.ts
+++ b/packages/mcp/src/auth/oauth-broker/mcp-access-token.ts
@@ -135,7 +135,9 @@ export function verifyMcpAccessToken(
     const decipher = createDecipheriv('aes-256-gcm', deriveEncryptionKey(config), iv);
     decipher.setAAD(AAD);
     decipher.setAuthTag(tag);
-    const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+    const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString(
+      'utf8',
+    );
     const parsed = JSON.parse(plaintext) as unknown;
     if (!isPayload(parsed)) return undefined;
 

--- a/packages/mcp/src/auth/oauth-broker/mcp-access-token.ts
+++ b/packages/mcp/src/auth/oauth-broker/mcp-access-token.ts
@@ -1,0 +1,143 @@
+import { createCipheriv, createDecipheriv, createHmac, randomBytes } from 'node:crypto';
+
+import type { McpHttpConfig } from '../../config/load-mcp-config.js';
+
+const TOKEN_PREFIX = 'ldmcp1';
+const KEY_CONTEXT = 'lightdash-tools:mcp-oauth-access-token:v1';
+const AAD = Buffer.from(KEY_CONTEXT, 'utf8');
+const IV_BYTES = 12;
+const AUTH_TAG_BYTES = 16;
+const MAX_TOKEN_LENGTH = 16 * 1024;
+
+export interface McpAccessTokenPayload {
+  v: 1;
+  /** Server-held downstream Lightdash credential. Never return this field to MCP clients. */
+  lightdashAccessToken: string;
+  /** MCP OAuth client_id that completed the broker flow. */
+  clientId: string;
+  /** Exact RFC 8707 MCP protected-resource URI this token is valid for. */
+  resource: string;
+  /** MCP authorization scope, not the downstream Lightdash token scope. */
+  scope?: string;
+  /** Unix timestamp in seconds. */
+  iat: number;
+  /** Unix timestamp in seconds. */
+  exp: number;
+}
+
+function deriveEncryptionKey(config: McpHttpConfig): Buffer {
+  if (!config.oauthClientSecret) {
+    throw new Error('OAuth client secret is required to protect MCP access tokens');
+  }
+
+  // The confidential Lightdash client secret is already shared by every broker replica.
+  // Derive a purpose-specific 256-bit key so the raw secret is never used directly as an AES key.
+  return createHmac('sha256', config.oauthClientSecret.expose()).update(KEY_CONTEXT).digest();
+}
+
+function isPayload(value: unknown): value is McpAccessTokenPayload {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    record.v === 1 &&
+    typeof record.lightdashAccessToken === 'string' &&
+    record.lightdashAccessToken.length > 0 &&
+    typeof record.clientId === 'string' &&
+    record.clientId.length > 0 &&
+    typeof record.resource === 'string' &&
+    record.resource.length > 0 &&
+    (record.scope === undefined || typeof record.scope === 'string') &&
+    typeof record.iat === 'number' &&
+    Number.isSafeInteger(record.iat) &&
+    typeof record.exp === 'number' &&
+    Number.isSafeInteger(record.exp)
+  );
+}
+
+export function mintMcpAccessToken(
+  config: McpHttpConfig,
+  input: {
+    lightdashAccessToken: string;
+    clientId: string;
+    resource: string;
+    scope?: string;
+    expiresAtMs: number;
+  },
+  nowMs = Date.now(),
+): { accessToken: string; expiresIn: number } {
+  const nowSeconds = Math.floor(nowMs / 1000);
+  const exp = Math.floor(input.expiresAtMs / 1000);
+  const expiresIn = exp - nowSeconds;
+  if (expiresIn <= 0) {
+    throw new Error('Upstream Lightdash access token is already expired');
+  }
+
+  const payload: McpAccessTokenPayload = {
+    v: 1,
+    lightdashAccessToken: input.lightdashAccessToken,
+    clientId: input.clientId,
+    resource: input.resource,
+    scope: input.scope,
+    iat: nowSeconds,
+    exp,
+  };
+
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv('aes-256-gcm', deriveEncryptionKey(config), iv);
+  cipher.setAAD(AAD);
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(payload), 'utf8'),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+
+  return {
+    accessToken: [
+      TOKEN_PREFIX,
+      iv.toString('base64url'),
+      ciphertext.toString('base64url'),
+      tag.toString('base64url'),
+    ].join('.'),
+    expiresIn,
+  };
+}
+
+/**
+ * Authenticates/decrypts an MCP-issued bearer token and enforces its exact resource audience.
+ * Returns undefined for malformed, tampered, expired, or cross-resource tokens.
+ */
+export function verifyMcpAccessToken(
+  config: McpHttpConfig,
+  token: string,
+  expectedResource: string,
+  nowMs = Date.now(),
+): McpAccessTokenPayload | undefined {
+  if (token.length === 0 || token.length > MAX_TOKEN_LENGTH) return undefined;
+
+  const parts = token.split('.');
+  if (parts.length !== 4 || parts[0] !== TOKEN_PREFIX) return undefined;
+
+  try {
+    const iv = Buffer.from(parts[1]!, 'base64url');
+    const ciphertext = Buffer.from(parts[2]!, 'base64url');
+    const tag = Buffer.from(parts[3]!, 'base64url');
+    if (iv.length !== IV_BYTES || tag.length !== AUTH_TAG_BYTES || ciphertext.length === 0) {
+      return undefined;
+    }
+
+    const decipher = createDecipheriv('aes-256-gcm', deriveEncryptionKey(config), iv);
+    decipher.setAAD(AAD);
+    decipher.setAuthTag(tag);
+    const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+    const parsed = JSON.parse(plaintext) as unknown;
+    if (!isPayload(parsed)) return undefined;
+
+    const nowSeconds = Math.floor(nowMs / 1000);
+    if (parsed.exp <= nowSeconds || parsed.iat > nowSeconds + 60) return undefined;
+    if (parsed.resource !== expectedResource) return undefined;
+
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/mcp/src/auth/oauth-broker/mcp-access-token.ts
+++ b/packages/mcp/src/auth/oauth-broker/mcp-access-token.ts
@@ -35,22 +35,29 @@ function deriveEncryptionKey(config: McpHttpConfig): Buffer {
   return createHmac('sha256', config.oauthClientSecret.expose()).update(KEY_CONTEXT).digest();
 }
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === 'string';
+}
+
+function isSafeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value);
+}
+
 function isPayload(value: unknown): value is McpAccessTokenPayload {
   if (typeof value !== 'object' || value === null) return false;
   const record = value as Record<string, unknown>;
   return (
     record.v === 1 &&
-    typeof record.lightdashAccessToken === 'string' &&
-    record.lightdashAccessToken.length > 0 &&
-    typeof record.clientId === 'string' &&
-    record.clientId.length > 0 &&
-    typeof record.resource === 'string' &&
-    record.resource.length > 0 &&
-    (record.scope === undefined || typeof record.scope === 'string') &&
-    typeof record.iat === 'number' &&
-    Number.isSafeInteger(record.iat) &&
-    typeof record.exp === 'number' &&
-    Number.isSafeInteger(record.exp)
+    isNonEmptyString(record.lightdashAccessToken) &&
+    isNonEmptyString(record.clientId) &&
+    isNonEmptyString(record.resource) &&
+    isOptionalString(record.scope) &&
+    isSafeInteger(record.iat) &&
+    isSafeInteger(record.exp)
   );
 }
 

--- a/packages/mcp/src/auth/oauth-broker/pending-store.test.ts
+++ b/packages/mcp/src/auth/oauth-broker/pending-store.test.ts
@@ -7,42 +7,49 @@ import { describe, expect, it } from 'vitest';
 
 import { InMemoryOAuthBrokerStore } from './pending-store.js';
 
+const RESOURCE = 'https://mcp.example.com/semantic-layer/v1/mcp';
+
+function pendingInput(clientId = 'c1') {
+  return {
+    clientId,
+    redirectUri: 'http://127.0.0.1:1/cb',
+    codeChallenge: 'ch',
+    codeChallengeMethod: 'S256',
+    resource: RESOURCE,
+  };
+}
+
 describe('InMemoryOAuthBrokerStore', () => {
-  it('createPending / takePending is single-use', async () => {
+  it('createPending / takePending is single-use and keeps the MCP resource', async () => {
     const store = new InMemoryOAuthBrokerStore();
-    const pending = await store.createPending({
-      clientId: 'c1',
-      redirectUri: 'http://127.0.0.1:1/cb',
-      codeChallenge: 'ch',
-      codeChallengeMethod: 'S256',
-    });
+    const pending = await store.createPending(pendingInput());
     expect(pending?.brokerState).toBeTruthy();
+    expect(pending?.resource).toBe(RESOURCE);
     expect((await store.takePending(pending!.brokerState))?.clientId).toBe('c1');
     expect(await store.takePending(pending!.brokerState)).toBeUndefined();
   });
 
-  it('issueCode / takeCode is single-use', async () => {
+  it('issueCode / takeCode is single-use and carries MCP resource/scope', async () => {
     const store = new InMemoryOAuthBrokerStore();
-    const pending = await store.createPending({
-      clientId: 'c1',
-      redirectUri: 'http://127.0.0.1:1/cb',
-      codeChallenge: 'ch',
-      codeChallengeMethod: 'S256',
-    });
+    const pending = await store.createPending({ ...pendingInput(), scope: 'mcp:read' });
     const issued = await store.issueCode(pending!, { accessToken: 'tok' });
     expect(issued?.accessToken).toBe('tok');
+    expect(issued?.resource).toBe(RESOURCE);
+    expect(issued?.scope).toBe('mcp:read');
     expect((await store.takeCode(issued!.code))?.clientId).toBe('c1');
     expect(await store.takeCode(issued!.code)).toBeUndefined();
   });
 
+  it('does not substitute a downstream token scope for the MCP scope', async () => {
+    const store = new InMemoryOAuthBrokerStore();
+    const pending = await store.createPending({ ...pendingInput(), scope: 'mcp:write' });
+    const issued = await store.issueCode(pending!, { accessToken: 'tok' });
+    expect(issued?.scope).toBe('mcp:write');
+  });
+
   it('restoreCode re-inserts a taken code for retry', async () => {
     const store = new InMemoryOAuthBrokerStore({ codeTtlMs: 60_000 });
-    const pending = await store.createPending({
-      clientId: 'c1',
-      redirectUri: 'http://127.0.0.1:1/cb',
-      codeChallenge: 'ch',
-      codeChallengeMethod: 'S256',
-    });
+    const pending = await store.createPending(pendingInput());
     const issued = await store.issueCode(pending!, { accessToken: 'tok' });
     const taken = await store.takeCode(issued!.code);
     expect(taken?.accessToken).toBe('tok');
@@ -54,12 +61,7 @@ describe('InMemoryOAuthBrokerStore', () => {
 
   it('restoreCode skips codes whose TTL has already elapsed', async () => {
     const store = new InMemoryOAuthBrokerStore({ codeTtlMs: 1_000 });
-    const pending = await store.createPending({
-      clientId: 'c1',
-      redirectUri: 'http://127.0.0.1:1/cb',
-      codeChallenge: 'ch',
-      codeChallengeMethod: 'S256',
-    });
+    const pending = await store.createPending(pendingInput());
     const issued = await store.issueCode(pending!, { accessToken: 'tok' });
     const taken = await store.takeCode(issued!.code);
     expect(taken).toBeDefined();
@@ -70,12 +72,7 @@ describe('InMemoryOAuthBrokerStore', () => {
 
   it('getCode / deleteCode still work for peek diagnostics', async () => {
     const store = new InMemoryOAuthBrokerStore();
-    const pending = await store.createPending({
-      clientId: 'c1',
-      redirectUri: 'http://127.0.0.1:1/cb',
-      codeChallenge: 'ch',
-      codeChallengeMethod: 'S256',
-    });
+    const pending = await store.createPending(pendingInput());
     const issued = await store.issueCode(pending!, { accessToken: 'tok' });
     expect((await store.getCode(issued!.code))?.clientId).toBe('c1');
     await store.deleteCode(issued!.code);
@@ -96,21 +93,9 @@ describe('InMemoryOAuthBrokerStore', () => {
 
   it('enforces maxPending after cleanup', async () => {
     const store = new InMemoryOAuthBrokerStore({ maxPending: 1 });
-    const first = await store.createPending({
-      clientId: 'c1',
-      redirectUri: 'http://127.0.0.1:1/cb',
-      codeChallenge: 'ch',
-      codeChallengeMethod: 'S256',
-    });
+    const first = await store.createPending(pendingInput());
     expect(first).toBeDefined();
-    expect(
-      await store.createPending({
-        clientId: 'c2',
-        redirectUri: 'http://127.0.0.1:1/cb',
-        codeChallenge: 'ch',
-        codeChallengeMethod: 'S256',
-      }),
-    ).toBeUndefined();
+    expect(await store.createPending(pendingInput('c2'))).toBeUndefined();
   });
 
   it('enforces maxClients', async () => {

--- a/packages/mcp/src/auth/oauth-broker/pending-store.ts
+++ b/packages/mcp/src/auth/oauth-broker/pending-store.ts
@@ -2,7 +2,8 @@
  * OAuth broker pending / codes / DCR clients (ADR-0007 / ADR-0019).
  *
  * All values are JSON-serializable. Backend: in-memory only — process-local.
- * Multi-instance OAuth needs sticky `/oauth/*` or a single replica until signed-state/CIMD.
+ * Multi-instance OAuth authorization/code exchange needs sticky `/oauth/*` or a single replica.
+ * Issued MCP access tokens are self-contained and do not depend on this store after exchange.
  */
 
 import { randomBytes } from 'node:crypto';
@@ -18,6 +19,9 @@ export interface PendingAuthorization {
   clientState?: string;
   codeChallenge: string;
   codeChallengeMethod: string;
+  /** Exact RFC 8707 MCP protected-resource URI requested by the client. */
+  resource: string;
+  /** MCP authorization scope. This is not a downstream Lightdash scope. */
   scope?: string;
   createdAt: number;
 }
@@ -28,9 +32,13 @@ export interface IssuedAuthorizationCode {
   redirectUri: string;
   codeChallenge: string;
   codeChallengeMethod: string;
+  /** Server-held downstream Lightdash access token; never return it directly to MCP clients. */
   accessToken: string;
   expiresIn?: number;
   tokenType: string;
+  /** Exact RFC 8707 MCP protected-resource URI bound during authorization. */
+  resource: string;
+  /** MCP authorization scope. */
   scope?: string;
   createdAt: number;
 }
@@ -78,7 +86,6 @@ export interface OAuthBrokerStore {
       accessToken: string;
       expiresIn?: number;
       tokenType?: string;
-      scope?: string;
     },
   ): Promise<IssuedAuthorizationCode | undefined>;
   /** Atomic get+delete for one-time code consume. */
@@ -177,7 +184,6 @@ export class InMemoryOAuthBrokerStore implements OAuthBrokerStore {
       accessToken: string;
       expiresIn?: number;
       tokenType?: string;
-      scope?: string;
     },
   ): Promise<IssuedAuthorizationCode | undefined> {
     this.cleanup();
@@ -193,7 +199,8 @@ export class InMemoryOAuthBrokerStore implements OAuthBrokerStore {
       accessToken: tokens.accessToken,
       expiresIn: tokens.expiresIn,
       tokenType: tokens.tokenType ?? 'Bearer',
-      scope: tokens.scope ?? pending.scope,
+      resource: pending.resource,
+      scope: pending.scope,
       createdAt: Date.now(),
     };
     this.codes.set(issued.code, issued);

--- a/packages/mcp/src/auth/oauth-broker/routes.test.ts
+++ b/packages/mcp/src/auth/oauth-broker/routes.test.ts
@@ -11,12 +11,15 @@ import {
   buildLightdashAuthorizeUrl,
   exchangeLightdashAuthorizationCode,
 } from './lightdash-token.js';
+import { verifyMcpAccessToken } from './mcp-access-token.js';
 import { InMemoryOAuthBrokerStore } from './pending-store.js';
 import { verifyPkce } from './pkce.js';
 import { createOAuthBroker } from './routes.js';
 
 import type { McpHttpConfig } from '../../config/load-mcp-config.js';
 import type { IncomingMessage, ServerResponse } from 'node:http';
+
+const RESOURCE = 'https://mcp.example.com/semantic-layer/v1/mcp';
 
 function baseConfig(overrides: Partial<McpHttpConfig> = {}): McpHttpConfig {
   return makeTestMcpHttpConfig({
@@ -93,16 +96,22 @@ function mockReq(
   return req;
 }
 
+function authorizeUrl(clientId: string, redirectUri: string, challenge: string): string {
+  return (
+    `/oauth/authorize?response_type=code&client_id=${encodeURIComponent(clientId)}` +
+    `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+    `&code_challenge=${encodeURIComponent(challenge)}&code_challenge_method=S256` +
+    `&resource=${encodeURIComponent(RESOURCE)}`
+  );
+}
+
 describe('oauth broker helpers', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('builds Lightdash authorize URL with fixed server callback', () => {
-    const url = buildLightdashAuthorizeUrl(baseConfig(), {
-      state: 'broker-state',
-      resource: 'https://mcp.example.com/semantic-layer/v1/mcp',
-    });
+  it('builds downstream Lightdash authorize URL without MCP resource/scope passthrough', () => {
+    const url = buildLightdashAuthorizeUrl(baseConfig(), { state: 'broker-state' });
     const parsed = new URL(url);
     expect(parsed.origin + parsed.pathname).toBe(
       'https://app.lightdash.cloud/api/v1/oauth/authorize',
@@ -111,6 +120,8 @@ describe('oauth broker helpers', () => {
     expect(parsed.searchParams.get('redirect_uri')).toBe('https://mcp.example.com/oauth/callback');
     expect(parsed.searchParams.get('state')).toBe('broker-state');
     expect(parsed.searchParams.get('code_challenge')).toBeNull();
+    expect(parsed.searchParams.get('resource')).toBeNull();
+    expect(parsed.searchParams.get('scope')).toBeNull();
   });
 
   it('publishes AS metadata pointing at broker endpoints', () => {
@@ -137,6 +148,7 @@ describe('oauth broker helpers', () => {
       redirectUri: 'http://127.0.0.1:9999/callback',
       codeChallenge: 'challenge',
       codeChallengeMethod: 'S256',
+      resource: RESOURCE,
     });
     expect(pending).toBeDefined();
     expect((await store.takePending(pending!.brokerState))?.clientId).toBe('client-a');
@@ -147,6 +159,7 @@ describe('oauth broker helpers', () => {
       redirectUri: 'http://127.0.0.1:9999/callback',
       codeChallenge: 'challenge',
       codeChallengeMethod: 'S256',
+      resource: RESOURCE,
     });
     expect(pending2).toBeDefined();
     const issued = await store.issueCode(pending2!, { accessToken: 'atok' });
@@ -154,6 +167,7 @@ describe('oauth broker helpers', () => {
     expect(issued).not.toHaveProperty('refreshToken');
     const taken = await store.takeCode(issued!.code);
     expect(taken?.accessToken).toBe('atok');
+    expect(taken?.resource).toBe(RESOURCE);
     expect(await store.takeCode(issued!.code)).toBeUndefined();
   });
 
@@ -187,6 +201,7 @@ describe('oauth broker helpers', () => {
       redirectUri: 'http://localhost:8787/callback',
       codeChallenge: challenge,
       codeChallengeMethod: 'S256',
+      resource: RESOURCE,
     });
     expect(pending).toBeDefined();
     const issued = await store.issueCode(pending!, { accessToken: 'atok' });
@@ -248,21 +263,20 @@ describe('oauth broker DCR + authorize binding', () => {
     const challenge = createHash('sha256').update('verifier').digest('base64url');
     const okRes = mockRes();
     await broker.handle(
-      mockReq(
-        'GET',
-        `/oauth/authorize?response_type=code&client_id=${encodeURIComponent(registered.client_id)}&redirect_uri=${encodeURIComponent(redirectUri)}&code_challenge=${challenge}&code_challenge_method=S256`,
-      ),
+      mockReq('GET', authorizeUrl(registered.client_id, redirectUri, challenge)),
       okRes,
       '/oauth/authorize',
     );
     expect(okRes.statusCode).toBe(302);
-    expect(String(okRes.headers.Location)).toContain('/api/v1/oauth/authorize');
+    const upstream = new URL(String(okRes.headers.Location));
+    expect(upstream.pathname).toContain('/api/v1/oauth/authorize');
+    expect(upstream.searchParams.get('resource')).toBeNull();
 
     const badRes = mockRes();
     await broker.handle(
       mockReq(
         'GET',
-        `/oauth/authorize?response_type=code&client_id=${encodeURIComponent(registered.client_id)}&redirect_uri=${encodeURIComponent('https://attacker.example/cb')}&code_challenge=${challenge}&code_challenge_method=S256`,
+        authorizeUrl(registered.client_id, 'https://attacker.example/cb', challenge),
       ),
       badRes,
       '/oauth/authorize',
@@ -278,7 +292,7 @@ describe('oauth broker DCR + authorize binding', () => {
     await broker.handle(
       mockReq(
         'GET',
-        `/oauth/authorize?response_type=code&client_id=unknown&redirect_uri=${encodeURIComponent('https://app.example/cb')}&code_challenge=${challenge}&code_challenge_method=S256`,
+        authorizeUrl('unknown', 'https://app.example/cb', challenge),
       ),
       res,
       '/oauth/authorize',
@@ -287,8 +301,49 @@ describe('oauth broker DCR + authorize binding', () => {
     expect((res.body as { error: string }).error).toBe('invalid_client');
   });
 
-  it('token response omits refresh_token even when upstream issued one', async () => {
+  it('requires a valid enabled MCP resource at authorize', async () => {
     const broker = createOAuthBroker(baseConfig());
+    const redirectUri = 'http://127.0.0.1:8787/callback';
+    const registerRes = mockRes();
+    await broker.handle(
+      mockReq('POST', '/oauth/register', `redirect_uris=${encodeURIComponent(redirectUri)}`),
+      registerRes,
+      '/oauth/register',
+    );
+    const { client_id: clientId } = registerRes.body as { client_id: string };
+    const challenge = createHash('sha256').update('verifier').digest('base64url');
+
+    const missingRes = mockRes();
+    await broker.handle(
+      mockReq(
+        'GET',
+        `/oauth/authorize?response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUri)}&code_challenge=${challenge}&code_challenge_method=S256`,
+      ),
+      missingRes,
+      '/oauth/authorize',
+    );
+    expect(missingRes.statusCode).toBe(400);
+    expect((missingRes.body as { error: string }).error).toBe('invalid_request');
+
+    const wrongRes = mockRes();
+    await broker.handle(
+      mockReq(
+        'GET',
+        authorizeUrl(clientId, redirectUri, challenge).replace(
+          encodeURIComponent(RESOURCE),
+          encodeURIComponent('https://attacker.example/mcp'),
+        ),
+      ),
+      wrongRes,
+      '/oauth/authorize',
+    );
+    expect(wrongRes.statusCode).toBe(400);
+    expect((wrongRes.body as { error: string }).error).toBe('invalid_target');
+  });
+
+  it('returns an MCP-issued resource-bound token and never exposes Lightdash tokens', async () => {
+    const config = baseConfig();
+    const broker = createOAuthBroker(config);
     const redirectUri = 'http://127.0.0.1:8787/callback';
     const verifier = 'test-verifier-value-1234567890';
     const challenge = createHash('sha256').update(verifier).digest('base64url');
@@ -303,16 +358,14 @@ describe('oauth broker DCR + authorize binding', () => {
 
     const authorizeRes = mockRes();
     await broker.handle(
-      mockReq(
-        'GET',
-        `/oauth/authorize?response_type=code&client_id=${encodeURIComponent(clientId)}&redirect_uri=${encodeURIComponent(redirectUri)}&code_challenge=${challenge}&code_challenge_method=S256`,
-      ),
+      mockReq('GET', authorizeUrl(clientId, redirectUri, challenge)),
       authorizeRes,
       '/oauth/authorize',
     );
     const ldAuthorize = new URL(String(authorizeRes.headers.Location));
     const brokerState = ldAuthorize.searchParams.get('state');
     expect(brokerState).toBeTruthy();
+    expect(ldAuthorize.searchParams.get('resource')).toBeNull();
 
     vi.stubGlobal(
       'fetch',
@@ -323,7 +376,7 @@ describe('oauth broker DCR + authorize binding', () => {
           refresh_token: 'ld-refresh-should-not-leak',
           expires_in: 3600,
           token_type: 'Bearer',
-          scope: 'openid',
+          scope: 'lightdash-upstream-scope-must-not-become-mcp-scope',
         }),
       }),
     );
@@ -353,6 +406,7 @@ describe('oauth broker DCR + authorize binding', () => {
           redirect_uri: redirectUri,
           client_id: clientId,
           code_verifier: verifier,
+          resource: RESOURCE,
         }).toString(),
       ),
       tokenRes,
@@ -360,7 +414,54 @@ describe('oauth broker DCR + authorize binding', () => {
     );
     expect(tokenRes.statusCode).toBe(200);
     const tokenBody = tokenRes.body as Record<string, unknown>;
-    expect(tokenBody.access_token).toBe('ld-access');
+    expect(tokenBody.access_token).not.toBe('ld-access');
+    expect(String(tokenBody.access_token)).toMatch(/^ldmcp1\./);
+    expect(String(tokenBody.access_token)).not.toContain('ld-access');
     expect(tokenBody).not.toHaveProperty('refresh_token');
+    expect(tokenBody.scope).toBeUndefined();
+
+    const decrypted = verifyMcpAccessToken(config, String(tokenBody.access_token), RESOURCE);
+    expect(decrypted).toMatchObject({
+      lightdashAccessToken: 'ld-access',
+      clientId,
+      resource: RESOURCE,
+    });
+  });
+
+  it('binds the token request to the same resource as the authorization request', async () => {
+    const store = new InMemoryOAuthBrokerStore();
+    const verifier = 'test-verifier-value-1234567890';
+    const challenge = createHash('sha256').update(verifier).digest('base64url');
+    const pending = await store.createPending({
+      clientId: 'client-a',
+      redirectUri: 'http://127.0.0.1:8787/callback',
+      codeChallenge: challenge,
+      codeChallengeMethod: 'S256',
+      resource: RESOURCE,
+    });
+    const issued = await store.issueCode(pending!, { accessToken: 'ld-access', expiresIn: 3600 });
+    const broker = createOAuthBroker(baseConfig(), store);
+
+    const res = mockRes();
+    await broker.handle(
+      mockReq(
+        'POST',
+        '/oauth/token',
+        new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: issued!.code,
+          redirect_uri: pending!.redirectUri,
+          client_id: pending!.clientId,
+          code_verifier: verifier,
+          resource: 'https://mcp.example.com/content-governance/v1/mcp',
+        }).toString(),
+      ),
+      res,
+      '/oauth/token',
+    );
+    expect(res.statusCode).toBe(400);
+    expect((res.body as { error: string; error_description: string }).error).toBe('invalid_grant');
+    expect((res.body as { error_description: string }).error_description).toBe('resource mismatch');
+    expect(await store.getCode(issued!.code)).toBeDefined();
   });
 });

--- a/packages/mcp/src/auth/oauth-broker/routes.test.ts
+++ b/packages/mcp/src/auth/oauth-broker/routes.test.ts
@@ -274,10 +274,7 @@ describe('oauth broker DCR + authorize binding', () => {
 
     const badRes = mockRes();
     await broker.handle(
-      mockReq(
-        'GET',
-        authorizeUrl(registered.client_id, 'https://attacker.example/cb', challenge),
-      ),
+      mockReq('GET', authorizeUrl(registered.client_id, 'https://attacker.example/cb', challenge)),
       badRes,
       '/oauth/authorize',
     );
@@ -290,10 +287,7 @@ describe('oauth broker DCR + authorize binding', () => {
     const challenge = createHash('sha256').update('verifier').digest('base64url');
     const res = mockRes();
     await broker.handle(
-      mockReq(
-        'GET',
-        authorizeUrl('unknown', 'https://app.example/cb', challenge),
-      ),
+      mockReq('GET', authorizeUrl('unknown', 'https://app.example/cb', challenge)),
       res,
       '/oauth/authorize',
     );

--- a/packages/mcp/src/auth/oauth-broker/routes.ts
+++ b/packages/mcp/src/auth/oauth-broker/routes.ts
@@ -395,12 +395,16 @@ type TokenGrantError = {
   body: { error: string; error_description: string };
 };
 
-async function validateTokenGrant(
-  params: URLSearchParams,
-  store: OAuthBrokerStore,
-): Promise<TokenGrantError | { issued: IssuedAuthorizationCode }> {
-  const grantType = params.get('grant_type');
-  if (grantType !== 'authorization_code') {
+type TokenGrantRequest = {
+  code: string;
+  redirectUri: string;
+  clientId: string;
+  codeVerifier: string | undefined;
+  resource: string;
+};
+
+function parseTokenGrantRequest(params: URLSearchParams): TokenGrantError | TokenGrantRequest {
+  if (params.get('grant_type') !== 'authorization_code') {
     return {
       status: 400,
       body: {
@@ -427,9 +431,31 @@ async function validateTokenGrant(
     };
   }
 
+  return { code, redirectUri, clientId, codeVerifier, resource };
+}
+
+async function restoreInvalidGrant(
+  store: OAuthBrokerStore,
+  candidate: IssuedAuthorizationCode,
+  description: string,
+): Promise<TokenGrantError> {
+  await store.restoreCode(candidate);
+  return {
+    status: 400,
+    body: { error: 'invalid_grant', error_description: description },
+  };
+}
+
+async function validateTokenGrant(
+  params: URLSearchParams,
+  store: OAuthBrokerStore,
+): Promise<TokenGrantError | { issued: IssuedAuthorizationCode }> {
+  const request = parseTokenGrantRequest(params);
+  if ('status' in request) return request;
+
   // Atomic take first. Restore on validation failure so a bad verifier / redirect /
   // resource does not permanently burn a one-time code.
-  const candidate = await store.takeCode(code);
+  const candidate = await store.takeCode(request.code);
   if (!candidate) {
     return {
       status: 400,
@@ -437,36 +463,20 @@ async function validateTokenGrant(
     };
   }
 
-  if (candidate.redirectUri !== redirectUri) {
-    await store.restoreCode(candidate);
-    return {
-      status: 400,
-      body: { error: 'invalid_grant', error_description: 'redirect_uri mismatch' },
-    };
+  if (candidate.redirectUri !== request.redirectUri) {
+    return restoreInvalidGrant(store, candidate, 'redirect_uri mismatch');
   }
 
-  if (candidate.clientId !== clientId) {
-    await store.restoreCode(candidate);
-    return {
-      status: 400,
-      body: { error: 'invalid_grant', error_description: 'client_id mismatch' },
-    };
+  if (candidate.clientId !== request.clientId) {
+    return restoreInvalidGrant(store, candidate, 'client_id mismatch');
   }
 
-  if (candidate.resource !== resource) {
-    await store.restoreCode(candidate);
-    return {
-      status: 400,
-      body: { error: 'invalid_grant', error_description: 'resource mismatch' },
-    };
+  if (candidate.resource !== request.resource) {
+    return restoreInvalidGrant(store, candidate, 'resource mismatch');
   }
 
-  if (!verifyPkce(codeVerifier, candidate.codeChallenge, candidate.codeChallengeMethod)) {
-    await store.restoreCode(candidate);
-    return {
-      status: 400,
-      body: { error: 'invalid_grant', error_description: 'PKCE verification failed' },
-    };
+  if (!verifyPkce(request.codeVerifier, candidate.codeChallenge, candidate.codeChallengeMethod)) {
+    return restoreInvalidGrant(store, candidate, 'PKCE verification failed');
   }
 
   return { issued: candidate };

--- a/packages/mcp/src/auth/oauth-broker/routes.ts
+++ b/packages/mcp/src/auth/oauth-broker/routes.ts
@@ -1,3 +1,4 @@
+import { listEnabledProfilePaths } from '../../config/enabled-profiles.js';
 import {
   OAUTH_AUTHORIZATION_SERVER_METADATA_PATH,
   OAUTH_AUTHORIZE_PATH,
@@ -6,6 +7,7 @@ import {
   OAUTH_TOKEN_PATH,
 } from '../../config/env.js';
 import { isLocalHttpOrigin } from '../../config/normalize-url.js';
+import { requirePublicUrl } from '../../config/public-url.js';
 import { parseJsonBody, readBody } from '../../transports/http-body.js';
 import { sendJson } from '../../transports/http-response.js';
 
@@ -14,6 +16,7 @@ import {
   buildLightdashAuthorizeUrl,
   exchangeLightdashAuthorizationCode,
 } from './lightdash-token.js';
+import { mintMcpAccessToken } from './mcp-access-token.js';
 import { InMemoryOAuthBrokerStore } from './pending-store.js';
 import { verifyPkce } from './pkce.js';
 
@@ -118,6 +121,13 @@ function isAllowedClientRedirectUri(redirectUri: string): boolean {
   }
 }
 
+function isAllowedMcpResource(config: McpHttpConfig, resource: string): boolean {
+  const publicUrl = requirePublicUrl(config, 'OAuth resource validation');
+  return listEnabledProfilePaths(config.enabledProfiles).some(
+    (profilePath) => resource === `${publicUrl}${profilePath}`,
+  );
+}
+
 type AuthorizeParseFail = { ok: false; status: number; body: Record<string, string> };
 
 async function parseRegisteredClientRedirect(
@@ -176,6 +186,7 @@ async function parseRegisteredClientRedirect(
 
 async function parseAuthorizeRequest(
   query: URLSearchParams,
+  config: McpHttpConfig,
   store: OAuthBrokerStore,
 ): Promise<
   | AuthorizeParseFail
@@ -186,7 +197,7 @@ async function parseAuthorizeRequest(
         redirectUri: string;
         clientState?: string;
         codeChallenge: string;
-        resource?: string;
+        resource: string;
         scope?: string;
       };
     }
@@ -221,6 +232,29 @@ async function parseAuthorizeRequest(
     };
   }
 
+  const resources = query.getAll('resource');
+  if (resources.length !== 1 || resources[0]!.length === 0) {
+    return {
+      ok: false,
+      status: 400,
+      body: {
+        error: 'invalid_request',
+        error_description: 'Exactly one MCP resource parameter is required',
+      },
+    };
+  }
+  const resource = resources[0]!;
+  if (!isAllowedMcpResource(config, resource)) {
+    return {
+      ok: false,
+      status: 400,
+      body: {
+        error: 'invalid_target',
+        error_description: 'resource must identify an enabled MCP profile endpoint',
+      },
+    };
+  }
+
   return {
     ok: true,
     value: {
@@ -228,7 +262,7 @@ async function parseAuthorizeRequest(
       redirectUri: registered.redirectUri,
       clientState: query.get('state') ?? undefined,
       codeChallenge,
-      resource: query.get('resource') ?? undefined,
+      resource,
       scope: query.get('scope') ?? undefined,
     },
   };
@@ -245,7 +279,7 @@ async function handleAuthorize(
     return;
   }
 
-  const parsed = await parseAuthorizeRequest(readQuery(req), store);
+  const parsed = await parseAuthorizeRequest(readQuery(req), config, store);
   if (!parsed.ok) {
     sendJson(res, parsed.status, parsed.body);
     return;
@@ -258,6 +292,7 @@ async function handleAuthorize(
     clientState,
     codeChallenge,
     codeChallengeMethod: 'S256',
+    resource,
     scope,
   });
   if (!pending) {
@@ -265,14 +300,9 @@ async function handleAuthorize(
     return;
   }
 
-  redirect(
-    res,
-    buildLightdashAuthorizeUrl(config, {
-      state: pending.brokerState,
-      scope,
-      resource,
-    }),
-  );
+  // The MCP resource/scope belong to the client→broker leg. Do not forward them
+  // to Lightdash, whose OAuth client and protected resource are distinct.
+  redirect(res, buildLightdashAuthorizeUrl(config, { state: pending.brokerState }));
 }
 
 function redirectToClient(
@@ -331,12 +361,13 @@ async function handleCallback(
 
   try {
     const tokens = await exchangeLightdashAuthorizationCode(config, code);
-    // Do not persist/return refresh_token: broker only supports authorization_code.
+    // The downstream credential remains server-side. The later MCP token endpoint
+    // wraps it in an authenticated-encrypted, resource-bound broker token.
+    // Refresh tokens are deliberately neither persisted nor returned.
     const issued = await store.issueCode(pending, {
       accessToken: tokens.access_token,
       expiresIn: tokens.expires_in,
       tokenType: tokens.token_type,
-      scope: tokens.scope,
     });
     if (!issued) {
       redirectToClient(res, pending.redirectUri, {
@@ -383,19 +414,21 @@ async function validateTokenGrant(
   const redirectUri = params.get('redirect_uri');
   const clientId = params.get('client_id');
   const codeVerifier = params.get('code_verifier') ?? undefined;
+  const resources = params.getAll('resource');
+  const resource = resources.length === 1 ? resources[0] : undefined;
 
-  if (!code || !redirectUri || !clientId) {
+  if (!code || !redirectUri || !clientId || !resource) {
     return {
       status: 400,
       body: {
         error: 'invalid_request',
-        error_description: 'code, redirect_uri, and client_id are required',
+        error_description: 'code, redirect_uri, client_id, and exactly one resource are required',
       },
     };
   }
 
-  // Atomic take first (multi-instance safe). Restore on validation failure so a
-  // bad verifier / redirect does not permanently burn a one-time code.
+  // Atomic take first. Restore on validation failure so a bad verifier / redirect /
+  // resource does not permanently burn a one-time code.
   const candidate = await store.takeCode(code);
   if (!candidate) {
     return {
@@ -417,6 +450,14 @@ async function validateTokenGrant(
     return {
       status: 400,
       body: { error: 'invalid_grant', error_description: 'client_id mismatch' },
+    };
+  }
+
+  if (candidate.resource !== resource) {
+    await store.restoreCode(candidate);
+    return {
+      status: 400,
+      body: { error: 'invalid_grant', error_description: 'resource mismatch' },
     };
   }
 
@@ -452,12 +493,29 @@ async function handleToken(
   }
 
   const { issued } = grant;
-  sendJson(res, 200, {
-    access_token: issued.accessToken,
-    token_type: issued.tokenType,
-    expires_in: issued.expiresIn ?? 3600,
-    scope: issued.scope,
-  });
+  const upstreamLifetimeSeconds = issued.expiresIn ?? 3600;
+  const expiresAtMs = issued.createdAt + upstreamLifetimeSeconds * 1000;
+
+  try {
+    const minted = mintMcpAccessToken(config, {
+      lightdashAccessToken: issued.accessToken,
+      clientId: issued.clientId,
+      resource: issued.resource,
+      scope: issued.scope,
+      expiresAtMs,
+    });
+    sendJson(res, 200, {
+      access_token: minted.accessToken,
+      token_type: 'Bearer',
+      expires_in: minted.expiresIn,
+      scope: issued.scope,
+    });
+  } catch {
+    sendJson(res, 400, {
+      error: 'invalid_grant',
+      error_description: 'Upstream Lightdash credential expired before broker token issuance',
+    });
+  }
 }
 
 async function handleRegister(
@@ -532,7 +590,8 @@ export function isOAuthBrokerPath(path: string): boolean {
 
 /**
  * Creates the OAuth broker request handler for co-located AS façade routes.
- * Pending state is process-local (InMemoryOAuthBrokerStore); sticky `/oauth/*` for multi-instance.
+ * Pending authorization/code state is process-local, so `/oauth/*` still needs
+ * sticky routing or one replica. Issued MCP access tokens are self-contained.
  */
 export function createOAuthBroker(
   config: McpHttpConfig,

--- a/packages/mcp/src/auth/resource-server/lightdash-oauth-middleware.test.ts
+++ b/packages/mcp/src/auth/resource-server/lightdash-oauth-middleware.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it, vi } from 'vitest';
+import { SecretString } from '@lightdash-tools/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { makeTestMcpHttpConfig } from '../../config/test-mcp-http-config.js';
 import { ORGANIZATION_AUDIT_PROFILE_PATH } from '../../profiles/organization-audit/v1/index.js';
 import { SEMANTIC_LAYER_PROFILE_PATH } from '../../profiles/semantic-layer/v1/index.js';
+import { mintMcpAccessToken } from '../oauth-broker/mcp-access-token.js';
 
 import { authenticateLightdashOAuth, writeOAuthAuthFailure } from './lightdash-oauth-middleware.js';
 import { validateLightdashAccessToken } from './lightdash-token-validation.js';
@@ -15,14 +17,10 @@ vi.mock('./lightdash-token-validation.js', () => ({
 }));
 
 const baseConfig = makeTestMcpHttpConfig({
+  oauthClientId: 'ld-client',
+  oauthClientSecret: new SecretString('test-lightdash-confidential-client-secret'),
   requiredScopes: [],
 });
-
-function jwtWithScope(scope: string): string {
-  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
-  const payload = Buffer.from(JSON.stringify({ scope })).toString('base64url');
-  return `${header}.${payload}.signature`;
-}
 
 function createRequest(authorization?: string): IncomingMessage {
   return {
@@ -30,7 +28,31 @@ function createRequest(authorization?: string): IncomingMessage {
   } as IncomingMessage;
 }
 
+function resourceFor(path: string): string {
+  return `https://mcp.example.com${path}`;
+}
+
+function mcpToken(options: {
+  path?: string;
+  scope?: string;
+  lightdashAccessToken?: string;
+  expiresAtMs?: number;
+} = {}): string {
+  const path = options.path ?? SEMANTIC_LAYER_PROFILE_PATH;
+  return mintMcpAccessToken(baseConfig, {
+    lightdashAccessToken: options.lightdashAccessToken ?? 'ld-upstream-token',
+    clientId: 'mcp-client-1',
+    resource: resourceFor(path),
+    scope: options.scope,
+    expiresAtMs: options.expiresAtMs ?? Date.now() + 60_000,
+  }).accessToken;
+}
+
 describe('authenticateLightdashOAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('returns 401 with WWW-Authenticate resource_metadata when token is missing', async () => {
     const result = await authenticateLightdashOAuth(
       createRequest(),
@@ -69,12 +91,43 @@ describe('authenticateLightdashOAuth', () => {
     expect(result.wwwAuthenticate).not.toContain('semantic-layer/v1/mcp');
   });
 
-  it('returns 401 without echoing the bearer token when validation fails', async () => {
+  it('rejects a raw downstream Lightdash bearer before calling Lightdash', async () => {
+    const token = 'ld-upstream-token';
+    const result = await authenticateLightdashOAuth(
+      createRequest(`Bearer ${token}`),
+      baseConfig,
+      SEMANTIC_LAYER_PROFILE_PATH,
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(401);
+    expect(result.body.error).toBe('invalid_token');
+    expect(JSON.stringify(result.body)).not.toContain(token);
+    expect(validateLightdashAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects a valid broker token at a different profile resource', async () => {
+    const token = mcpToken({ path: ORGANIZATION_AUDIT_PROFILE_PATH });
+    const result = await authenticateLightdashOAuth(
+      createRequest(`Bearer ${token}`),
+      baseConfig,
+      SEMANTIC_LAYER_PROFILE_PATH,
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(401);
+    expect(result.body.error_description).toContain('wrong-audience');
+    expect(validateLightdashAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 without echoing the MCP bearer when downstream validation fails', async () => {
     vi.mocked(validateLightdashAccessToken).mockRejectedValue(
       new TokenValidationError('invalid_token', 'Invalid or expired Lightdash access token'),
     );
 
-    const token = 'secret-oauth-token';
+    const token = mcpToken();
     const result = await authenticateLightdashOAuth(
       createRequest(`Bearer ${token}`),
       baseConfig,
@@ -86,9 +139,9 @@ describe('authenticateLightdashOAuth', () => {
 
     expect(result.status).toBe(401);
     expect(result.body.error).toBe('invalid_token');
-    expect(result.body.error_description).toBe('Invalid or expired Lightdash access token');
     expect(JSON.stringify(result.body)).not.toContain(token);
     expect(result.wwwAuthenticate).toContain('error="invalid_token"');
+    expect(validateLightdashAccessToken).toHaveBeenCalledWith(baseConfig, 'ld-upstream-token');
   });
 
   it('returns 503 when Lightdash upstream is unavailable', async () => {
@@ -97,7 +150,7 @@ describe('authenticateLightdashOAuth', () => {
     );
 
     const result = await authenticateLightdashOAuth(
-      createRequest('Bearer token'),
+      createRequest(`Bearer ${mcpToken()}`),
       baseConfig,
       SEMANTIC_LAYER_PROFILE_PATH,
     );
@@ -119,7 +172,7 @@ describe('authenticateLightdashOAuth', () => {
     );
 
     const result = await authenticateLightdashOAuth(
-      createRequest('Bearer token'),
+      createRequest(`Bearer ${mcpToken()}`),
       baseConfig,
       SEMANTIC_LAYER_PROFILE_PATH,
     );
@@ -131,13 +184,13 @@ describe('authenticateLightdashOAuth', () => {
     expect(result.headers).toEqual({ 'Retry-After': '60' });
   });
 
-  it('returns user context when token validation succeeds', async () => {
+  it('returns downstream user context only after broker-token validation succeeds', async () => {
     vi.mocked(validateLightdashAccessToken).mockResolvedValue({
       userUuid: 'user-uuid-1',
       email: 'user@example.com',
     });
 
-    const token = jwtWithScope('mcp:read mcp:write');
+    const token = mcpToken({ scope: 'mcp:read mcp:write' });
     const result = await authenticateLightdashOAuth(
       createRequest(`Bearer ${token}`),
       baseConfig,
@@ -146,45 +199,21 @@ describe('authenticateLightdashOAuth', () => {
 
     expect(result).toEqual({
       ok: true,
-      accessToken: token,
+      accessToken: 'ld-upstream-token',
       user: { userUuid: 'user-uuid-1', email: 'user@example.com' },
       scopes: ['mcp:read', 'mcp:write'],
     });
-    expect(validateLightdashAccessToken).toHaveBeenCalledWith(baseConfig, token);
+    expect(validateLightdashAccessToken).toHaveBeenCalledWith(baseConfig, 'ld-upstream-token');
   });
 
-  it('accepts opaque tokens when endpoint scope requirements are unset', async () => {
+  it('accepts an MCP token without scopes when endpoint scope requirements are unset', async () => {
     vi.mocked(validateLightdashAccessToken).mockResolvedValue({
       userUuid: 'user-uuid-1',
       email: 'user@example.com',
     });
 
     const result = await authenticateLightdashOAuth(
-      createRequest('Bearer opaque-token'),
-      baseConfig,
-      SEMANTIC_LAYER_PROFILE_PATH,
-    );
-
-    expect(result).toEqual({
-      ok: true,
-      accessToken: 'opaque-token',
-      user: { userUuid: 'user-uuid-1', email: 'user@example.com' },
-      scopes: undefined,
-    });
-  });
-
-  it('accepts JWTs without scope claims when endpoint scope requirements are unset', async () => {
-    vi.mocked(validateLightdashAccessToken).mockResolvedValue({
-      userUuid: 'user-uuid-1',
-      email: 'user@example.com',
-    });
-
-    const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
-    const payload = Buffer.from(JSON.stringify({ sub: 'user-uuid-1' })).toString('base64url');
-    const token = `${header}.${payload}.signature`;
-
-    const result = await authenticateLightdashOAuth(
-      createRequest(`Bearer ${token}`),
+      createRequest(`Bearer ${mcpToken()}`),
       baseConfig,
       SEMANTIC_LAYER_PROFILE_PATH,
     );
@@ -194,38 +223,9 @@ describe('authenticateLightdashOAuth', () => {
     expect(result.scopes).toBeUndefined();
   });
 
-  it('returns 403 insufficient_scope when required endpoint scopes are configured and missing', async () => {
-    vi.mocked(validateLightdashAccessToken).mockResolvedValue({
-      userUuid: 'user-uuid-1',
-      email: 'user@example.com',
-    });
-
+  it('returns 403 insufficient_scope before calling Lightdash when MCP scopes are missing', async () => {
     const scopedConfig = { ...baseConfig, requiredScopes: ['mcp:read'] };
-    const result = await authenticateLightdashOAuth(
-      createRequest('Bearer opaque-token'),
-      scopedConfig,
-      SEMANTIC_LAYER_PROFILE_PATH,
-    );
-
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-
-    expect(result.status).toBe(403);
-    expect(result.body.error).toBe('insufficient_scope');
-    expect(result.wwwAuthenticate).toContain('scope="mcp:read"');
-  });
-
-  it('returns 403 insufficient_scope when required scopes are missing from token claims', async () => {
-    vi.mocked(validateLightdashAccessToken).mockResolvedValue({
-      userUuid: 'user-uuid-1',
-      email: 'user@example.com',
-    });
-
-    const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
-    const payload = Buffer.from(JSON.stringify({ scope: 'mcp:write' })).toString('base64url');
-    const token = `${header}.${payload}.signature`;
-
-    const scopedConfig = { ...baseConfig, requiredScopes: ['mcp:read'] };
+    const token = mcpToken({ scope: 'mcp:write' });
     const result = await authenticateLightdashOAuth(
       createRequest(`Bearer ${token}`),
       scopedConfig,
@@ -238,6 +238,8 @@ describe('authenticateLightdashOAuth', () => {
     expect(result.status).toBe(403);
     expect(result.body.error).toBe('insufficient_scope');
     expect(result.wwwAuthenticate).toContain('error="insufficient_scope"');
+    expect(result.wwwAuthenticate).toContain('scope="mcp:read"');
+    expect(validateLightdashAccessToken).not.toHaveBeenCalled();
   });
 
   it('accepts lowercase bearer scheme prefix', async () => {
@@ -246,16 +248,15 @@ describe('authenticateLightdashOAuth', () => {
       email: 'user@example.com',
     });
 
-    const token = jwtWithScope('mcp:read mcp:write');
     const result = await authenticateLightdashOAuth(
-      createRequest(`bearer ${token}`),
+      createRequest(`bearer ${mcpToken()}`),
       baseConfig,
       SEMANTIC_LAYER_PROFILE_PATH,
     );
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.accessToken).toBe(token);
+    expect(result.accessToken).toBe('ld-upstream-token');
   });
 });
 

--- a/packages/mcp/src/auth/resource-server/lightdash-oauth-middleware.test.ts
+++ b/packages/mcp/src/auth/resource-server/lightdash-oauth-middleware.test.ts
@@ -32,12 +32,14 @@ function resourceFor(path: string): string {
   return `https://mcp.example.com${path}`;
 }
 
-function mcpToken(options: {
-  path?: string;
-  scope?: string;
-  lightdashAccessToken?: string;
-  expiresAtMs?: number;
-} = {}): string {
+function mcpToken(
+  options: {
+    path?: string;
+    scope?: string;
+    lightdashAccessToken?: string;
+    expiresAtMs?: number;
+  } = {},
+): string {
   const path = options.path ?? SEMANTIC_LAYER_PROFILE_PATH;
   return mintMcpAccessToken(baseConfig, {
     lightdashAccessToken: options.lightdashAccessToken ?? 'ld-upstream-token',

--- a/packages/mcp/src/auth/resource-server/lightdash-oauth-middleware.ts
+++ b/packages/mcp/src/auth/resource-server/lightdash-oauth-middleware.ts
@@ -1,9 +1,13 @@
 import { sendJson } from '../../transports/http-response.js';
 import { extractBearerToken } from '../bearer.js';
+import { verifyMcpAccessToken } from '../oauth-broker/mcp-access-token.js';
 
 import { validateLightdashAccessToken } from './lightdash-token-validation.js';
-import { getProtectedResourceMetadataPathUrl } from './oauth-protected-resource.js';
-import { extractTokenScopes, hasRequiredScopes } from './token-scopes.js';
+import {
+  buildOAuthProtectedResourceMetadata,
+  getProtectedResourceMetadataPathUrl,
+} from './oauth-protected-resource.js';
+import { hasRequiredScopes } from './token-scopes.js';
 import { TokenValidationError } from './token-validation-error.js';
 import { buildWwwAuthenticateHeader } from './www-authenticate.js';
 
@@ -13,8 +17,10 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 
 export interface OAuthAuthSuccess {
   ok: true;
+  /** Server-held downstream Lightdash credential. Never sourced directly from the MCP bearer. */
   accessToken: string;
   user: ValidatedLightdashUser;
+  /** MCP authorization scopes carried by the broker-issued token. */
   scopes: string[] | undefined;
 }
 
@@ -46,12 +52,40 @@ export function buildBearerRequiredFailure(
   };
 }
 
+function parseBrokerScopes(scope: string | undefined): string[] | undefined {
+  if (!scope) return undefined;
+  const scopes = scope.split(/\s+/).filter(Boolean);
+  return scopes.length > 0 ? scopes : undefined;
+}
+
+function invalidMcpTokenFailure(
+  resourceMetadataUrl: string,
+  scope: string,
+): OAuthAuthFailure {
+  const description = 'Invalid, expired, or wrong-audience MCP access token';
+  return {
+    ok: false,
+    status: 401,
+    body: {
+      error: 'invalid_token',
+      error_description: description,
+    },
+    wwwAuthenticate: buildWwwAuthenticateHeader({
+      resourceMetadataUrl,
+      scope,
+      error: 'invalid_token',
+      errorDescription: description,
+    }),
+  };
+}
+
 export async function authenticateLightdashOAuth(
   req: IncomingMessage,
   config: McpHttpConfig,
   mcpPath: string,
 ): Promise<OAuthAuthResult> {
   const resourceMetadataUrl = getProtectedResourceMetadataPathUrl(config, mcpPath);
+  const expectedResource = buildOAuthProtectedResourceMetadata(config, mcpPath).resource;
   const scope = config.requiredScopes.join(' ');
   const token = extractBearerToken(req);
 
@@ -59,35 +93,46 @@ export async function authenticateLightdashOAuth(
     return buildBearerRequiredFailure(config, mcpPath);
   }
 
-  try {
-    const user = await validateLightdashAccessToken(config, token);
-    const scopes = extractTokenScopes(token, config.scopesSupported, {
-      grantAllWhenUnknown: false,
-    });
-    if (
-      config.requiredScopes.length > 0 &&
-      !hasRequiredScopes(scopes ?? [], config.requiredScopes)
-    ) {
-      const missingScopes = config.requiredScopes.filter(
-        (scope) => !(scopes ?? []).includes(scope),
-      );
-      return {
-        ok: false,
-        status: 403,
-        body: {
-          error: 'insufficient_scope',
-          error_description: `Missing required OAuth scopes: ${missingScopes.join(', ')}`,
-        },
-        wwwAuthenticate: buildWwwAuthenticateHeader({
-          resourceMetadataUrl,
-          scope: config.requiredScopes.join(' '),
-          error: 'insufficient_scope',
-          errorDescription: `Missing required OAuth scopes: ${missingScopes.join(', ')}`,
-        }),
-      };
-    }
+  // The MCP resource server accepts only tokens minted by its co-located authorization
+  // server and bound to this exact profile resource. Raw Lightdash tokens fail here and
+  // are never passed through to the downstream API.
+  const brokerToken = verifyMcpAccessToken(config, token, expectedResource);
+  if (!brokerToken) {
+    return invalidMcpTokenFailure(resourceMetadataUrl, scope);
+  }
 
-    return { ok: true, accessToken: token, user, scopes };
+  const scopes = parseBrokerScopes(brokerToken.scope);
+  if (
+    config.requiredScopes.length > 0 &&
+    !hasRequiredScopes(scopes ?? [], config.requiredScopes)
+  ) {
+    const missingScopes = config.requiredScopes.filter(
+      (requiredScope) => !(scopes ?? []).includes(requiredScope),
+    );
+    return {
+      ok: false,
+      status: 403,
+      body: {
+        error: 'insufficient_scope',
+        error_description: `Missing required OAuth scopes: ${missingScopes.join(', ')}`,
+      },
+      wwwAuthenticate: buildWwwAuthenticateHeader({
+        resourceMetadataUrl,
+        scope: config.requiredScopes.join(' '),
+        error: 'insufficient_scope',
+        errorDescription: `Missing required OAuth scopes: ${missingScopes.join(', ')}`,
+      }),
+    };
+  }
+
+  try {
+    const user = await validateLightdashAccessToken(config, brokerToken.lightdashAccessToken);
+    return {
+      ok: true,
+      accessToken: brokerToken.lightdashAccessToken,
+      user,
+      scopes,
+    };
   } catch (error) {
     if (error instanceof TokenValidationError && error.reason === 'upstream_unavailable') {
       const headers =
@@ -105,20 +150,7 @@ export async function authenticateLightdashOAuth(
       };
     }
 
-    return {
-      ok: false,
-      status: 401,
-      body: {
-        error: 'invalid_token',
-        error_description: 'Invalid or expired Lightdash access token',
-      },
-      wwwAuthenticate: buildWwwAuthenticateHeader({
-        resourceMetadataUrl,
-        scope,
-        error: 'invalid_token',
-        errorDescription: 'Invalid or expired Lightdash access token',
-      }),
-    };
+    return invalidMcpTokenFailure(resourceMetadataUrl, scope);
   }
 }
 

--- a/packages/mcp/src/auth/resource-server/lightdash-oauth-middleware.ts
+++ b/packages/mcp/src/auth/resource-server/lightdash-oauth-middleware.ts
@@ -58,10 +58,7 @@ function parseBrokerScopes(scope: string | undefined): string[] | undefined {
   return scopes.length > 0 ? scopes : undefined;
 }
 
-function invalidMcpTokenFailure(
-  resourceMetadataUrl: string,
-  scope: string,
-): OAuthAuthFailure {
+function invalidMcpTokenFailure(resourceMetadataUrl: string, scope: string): OAuthAuthFailure {
   const description = 'Invalid, expired, or wrong-audience MCP access token';
   return {
     ok: false,
@@ -102,10 +99,7 @@ export async function authenticateLightdashOAuth(
   }
 
   const scopes = parseBrokerScopes(brokerToken.scope);
-  if (
-    config.requiredScopes.length > 0 &&
-    !hasRequiredScopes(scopes ?? [], config.requiredScopes)
-  ) {
+  if (config.requiredScopes.length > 0 && !hasRequiredScopes(scopes ?? [], config.requiredScopes)) {
     const missingScopes = config.requiredScopes.filter(
       (requiredScope) => !(scopes ?? []).includes(requiredScope),
     );

--- a/packages/mcp/src/auth/resource-server/oauth-protected-resource.ts
+++ b/packages/mcp/src/auth/resource-server/oauth-protected-resource.ts
@@ -31,8 +31,8 @@ export function buildOAuthProtectedResourceMetadata(
 
   // Broker mode: authorization_servers is the MCP host (PUBLIC_URL). Clients discover
   // AS metadata at {PUBLIC_URL}/.well-known/oauth-authorization-server and never need
-  // the Lightdash client secret. Identity validation remains GET /api/v1/user until
-  // upstream tokens are resource-bound.
+  // the Lightdash client secret. The broker issues its own access token bound to this
+  // exact resource; the downstream Lightdash credential remains a separate OAuth leg.
   return {
     resource: `${publicUrl}${path}`,
     authorization_servers: [publicUrl],

--- a/packages/mcp/src/config/load-mcp-config.ts
+++ b/packages/mcp/src/config/load-mcp-config.ts
@@ -260,16 +260,16 @@ function emitLightdashOAuthSecurityWarnings(config: McpHttpConfig): void {
   }
 
   console.warn(
-    'Note: hosted OAuth uses a server-held Lightdash confidential client (OAuth broker). ' +
-      'Token validation confirms Lightdash user identity via GET /api/v1/user; ' +
-      'opaque Lightdash tokens are not fully resource/audience-bound until upstream supports it. ' +
+    'Note: hosted OAuth uses a dual-leg broker with a server-held Lightdash confidential client. ' +
+      'MCP clients receive resource-bound broker tokens; delegated Lightdash access tokens remain ' +
+      'encrypted inside the broker token and are recovered only server-side for upstream calls. ' +
       `Register redirect URI ${getOAuthCallbackUrl(config)} in Lightdash.`,
   );
 
   if (!config.validateToken) {
     console.warn(
-      `Warning: ${ENV_LIGHTDASH_TOOLS_MCP_VALIDATE_TOKEN}=false — MCP accepts any bearer token without calling Lightdash. ` +
-        'Use only for local development.',
+      `Warning: ${ENV_LIGHTDASH_TOOLS_MCP_VALIDATE_TOKEN}=false — broker-issued MCP tokens are still authenticated and audience-bound, ` +
+        'but downstream Lightdash user/token validation is skipped. Use only for local development.',
     );
   }
 

--- a/packages/mcp/src/http.integration.test.ts
+++ b/packages/mcp/src/http.integration.test.ts
@@ -4,6 +4,7 @@ import { SecretString } from '@lightdash-tools/client';
 import { CLIENT_CAPABILITIES_META_KEY } from '@modelcontextprotocol/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { mintMcpAccessToken } from './auth/oauth-broker/mcp-access-token.js';
 import { getAuthorizationServerMetadataUrl } from './auth/resource-server/oauth-protected-resource.js';
 import { parseEnabledProfiles } from './config/enabled-profiles.js';
 import { makeTestMcpHttpConfig } from './config/test-mcp-http-config.js';
@@ -12,6 +13,8 @@ import { createStreamableHttpServer } from './transports/streamable-http.js';
 import type { McpHttpConfig } from './config/load-mcp-config.js';
 import type { AddressInfo } from 'node:net';
 
+// These constants model downstream Lightdash credentials only. MCP clients never send
+// them directly after ADR-0026; tests wrap them in broker-issued MCP access tokens.
 const TOKEN_A = scopedAccessToken('mcp:read mcp:write', 'token-a');
 const TOKEN_B = scopedAccessToken('mcp:read mcp:write', 'token-b');
 const TOKEN_READ_ONLY = scopedAccessToken('mcp:read', 'token-read-only');
@@ -168,6 +171,21 @@ function baseOAuthConfig(lightdashUrl: string, overrides?: Partial<McpHttpConfig
   });
 }
 
+function brokerAccessToken(
+  mcpBaseUrl: string,
+  lightdashAccessToken: string,
+  options: { path?: string; scope?: string } = {},
+): string {
+  const path = options.path ?? '/semantic-layer/v1/mcp';
+  return mintMcpAccessToken(baseOAuthConfig('https://lightdash.invalid'), {
+    lightdashAccessToken,
+    clientId: 'integration-test-client',
+    resource: `${mcpBaseUrl}${path}`,
+    scope: options.scope,
+    expiresAtMs: Date.now() + 60_000,
+  }).accessToken;
+}
+
 async function postMcp(
   baseUrl: string,
   body: unknown,
@@ -240,13 +258,16 @@ describe('MCP HTTP OAuth integration (RFC §16.3 matrix)', () => {
     expect(response.headers.get('www-authenticate')).toContain('invalid_token');
   });
 
-  it('handles initialize with valid OAuth bearer and validates upstream Authorization', async () => {
-    const response = await postMcp(mcpServer.baseUrl, INITIALIZE_BODY, { token: TOKEN_A });
+  it('handles initialize with an MCP bearer and validates the downstream Lightdash bearer', async () => {
+    const mcpToken = brokerAccessToken(mcpServer.baseUrl, TOKEN_A);
+    const response = await postMcp(mcpServer.baseUrl, INITIALIZE_BODY, { token: mcpToken });
 
     expect(response.status).toBe(200);
-    // Sessionless: no session-id header is set
+    // Sessionless: no session-id header is set.
     expect(response.headers.get('mcp-session-id')).toBeFalsy();
+    expect(mcpToken).not.toBe(TOKEN_A);
     expect(mockLightdash.authorizationHeaders).toContain(`Bearer ${TOKEN_A}`);
+    expect(mockLightdash.authorizationHeaders).not.toContain(`Bearer ${mcpToken}`);
   });
 
   it('returns 401 before parsing malformed JSON when OAuth token is missing', async () => {
@@ -273,12 +294,13 @@ describe('MCP HTTP OAuth integration (RFC §16.3 matrix)', () => {
   });
 
   it('returns 400 for malformed JSON only after successful OAuth authentication', async () => {
+    const mcpToken = brokerAccessToken(mcpServer.baseUrl, TOKEN_A);
     const response = await fetch(`${mcpServer.baseUrl}/semantic-layer/v1/mcp`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json, text/event-stream',
-        Authorization: `Bearer ${TOKEN_A}`,
+        Authorization: `Bearer ${mcpToken}`,
       },
       body: '{not-json',
     });
@@ -385,18 +407,23 @@ describe('MCP HTTP OAuth integration (RFC §16.3 matrix)', () => {
     expect(wwwAuthenticate).not.toContain('semantic-layer/v1/mcp');
   });
 
-  it('maps token-a and token-b to distinct authenticated users upstream', async () => {
-    const responseA = await postMcp(mcpServer.baseUrl, INITIALIZE_BODY, { token: TOKEN_A });
-    const responseB = await postMcp(mcpServer.baseUrl, INITIALIZE_BODY, { token: TOKEN_B });
+  it('maps two MCP tokens to distinct authenticated users upstream', async () => {
+    const mcpTokenA = brokerAccessToken(mcpServer.baseUrl, TOKEN_A);
+    const mcpTokenB = brokerAccessToken(mcpServer.baseUrl, TOKEN_B);
+    const responseA = await postMcp(mcpServer.baseUrl, INITIALIZE_BODY, { token: mcpTokenA });
+    const responseB = await postMcp(mcpServer.baseUrl, INITIALIZE_BODY, { token: mcpTokenB });
 
     expect(responseA.status).toBe(200);
     expect(responseB.status).toBe(200);
     expect(mockLightdash.authorizationHeaders).toContain(`Bearer ${TOKEN_A}`);
     expect(mockLightdash.authorizationHeaders).toContain(`Bearer ${TOKEN_B}`);
+    expect(mockLightdash.authorizationHeaders).not.toContain(`Bearer ${mcpTokenA}`);
+    expect(mockLightdash.authorizationHeaders).not.toContain(`Bearer ${mcpTokenB}`);
   });
 
   it('accepts form-elicitation caps from per-request _meta on content-governance tools/call', async () => {
     const governancePath = '/content-governance/v1/mcp';
+    const mcpToken = brokerAccessToken(mcpServer.baseUrl, TOKEN_A, { path: governancePath });
     const call = await postMcp(
       mcpServer.baseUrl,
       {
@@ -414,7 +441,7 @@ describe('MCP HTTP OAuth integration (RFC §16.3 matrix)', () => {
         },
         id: 2,
       },
-      { token: TOKEN_A, path: governancePath },
+      { token: mcpToken, path: governancePath },
     );
     expect(call.status).toBe(200);
     const text = parseSseOrJsonToolText(await call.text());
@@ -441,7 +468,8 @@ describe('MCP HTTP OAuth integration (RFC §16.3 matrix)', () => {
     });
 
     try {
-      const response = await postMcp(downServer.baseUrl, INITIALIZE_BODY, { token: TOKEN_A });
+      const mcpToken = brokerAccessToken(downServer.baseUrl, TOKEN_A);
+      const response = await postMcp(downServer.baseUrl, INITIALIZE_BODY, { token: mcpToken });
       expect(response.status).toBe(503);
       expect(await response.json()).toEqual({
         error: 'temporarily_unavailable',
@@ -501,42 +529,50 @@ describe('MCP HTTP OAuth integration (continued)', () => {
     expect(asMetadata.registration_endpoint).toBe(`${mcpServer.baseUrl}/oauth/register`);
   });
 
-  it('handles initialize with opaque OAuth bearer when endpoint scopes are unset', async () => {
-    const response = await postMcp(mcpServer.baseUrl, INITIALIZE_BODY, { token: OPAQUE_TOKEN_A });
+  it('handles initialize when the downstream Lightdash credential is opaque', async () => {
+    const mcpToken = brokerAccessToken(mcpServer.baseUrl, OPAQUE_TOKEN_A);
+    const response = await postMcp(mcpServer.baseUrl, INITIALIZE_BODY, { token: mcpToken });
 
     expect(response.status).toBe(200);
     expect(response.headers.get('mcp-session-id')).toBeFalsy();
     expect(mockLightdash.authorizationHeaders).toContain(`Bearer ${OPAQUE_TOKEN_A}`);
+    expect(mockLightdash.authorizationHeaders).not.toContain(`Bearer ${mcpToken}`);
   });
 
-  it('accepts TOKEN_READ_ONLY (mcp:read scope) on initialize', async () => {
+  it('accepts an MCP token carrying mcp:read scope on initialize', async () => {
+    const mcpToken = brokerAccessToken(mcpServer.baseUrl, TOKEN_READ_ONLY, { scope: 'mcp:read' });
     const response = await postMcp(mcpServer.baseUrl, INITIALIZE_BODY, {
-      token: TOKEN_READ_ONLY,
+      token: mcpToken,
     });
 
     expect(response.status).toBe(200);
     expect(mockLightdash.authorizationHeaders).toContain(`Bearer ${TOKEN_READ_ONLY}`);
   });
 
-  it('accepts TOKEN_A (mcp:read mcp:write scope) on initialize', async () => {
+  it('accepts an MCP token carrying mcp:read mcp:write scope on initialize', async () => {
+    const mcpToken = brokerAccessToken(mcpServer.baseUrl, TOKEN_A, {
+      scope: 'mcp:read mcp:write',
+    });
     const response = await postMcp(mcpServer.baseUrl, INITIALIZE_BODY, {
-      token: TOKEN_A,
+      token: mcpToken,
     });
 
     expect(response.status).toBe(200);
     expect(mockLightdash.authorizationHeaders).toContain(`Bearer ${TOKEN_A}`);
   });
 
-  it('forwards bearer token to Lightdash on initialize for opaque credentials', async () => {
+  it('forwards only the decrypted downstream bearer to Lightdash', async () => {
+    const mcpToken = brokerAccessToken(mcpServer.baseUrl, OPAQUE_TOKEN_A);
     const response = await postMcp(mcpServer.baseUrl, INITIALIZE_BODY, {
-      token: OPAQUE_TOKEN_A,
+      token: mcpToken,
     });
 
     expect(response.status).toBe(200);
-    const userHeaders = mockLightdash.authorizationHeaders.filter(
-      (h) => h === `Bearer ${OPAQUE_TOKEN_A}`,
+    const downstreamHeaders = mockLightdash.authorizationHeaders.filter(
+      (header) => header === `Bearer ${OPAQUE_TOKEN_A}`,
     );
-    expect(userHeaders.length).toBeGreaterThan(0);
+    expect(downstreamHeaders.length).toBeGreaterThan(0);
+    expect(mockLightdash.authorizationHeaders).not.toContain(`Bearer ${mcpToken}`);
   });
 });
 
@@ -620,13 +656,14 @@ describe('MCP HTTP transport (sessionless)', () => {
       ...INITIALIZE_BODY,
       params: { ...INITIALIZE_BODY.params, padding: 'x'.repeat(1024) },
     });
+    const mcpToken = brokerAccessToken(mcpServer.baseUrl, TOKEN_A);
 
     const response = await fetch(`${mcpServer.baseUrl}/semantic-layer/v1/mcp`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json, text/event-stream',
-        Authorization: `Bearer ${TOKEN_A}`,
+        Authorization: `Bearer ${mcpToken}`,
       },
       body: hugeBody,
     });
@@ -691,9 +728,11 @@ describe('MCP HTTP profile mount allowlist', () => {
   });
 
   it('keeps enabled profile MCP and PRM reachable', async () => {
+    const contentReaderPath = '/content-reader/v1/mcp';
+    const mcpToken = brokerAccessToken(mcpServer.baseUrl, TOKEN_A, { path: contentReaderPath });
     const mcpResponse = await postMcp(mcpServer.baseUrl, INITIALIZE_BODY, {
-      token: TOKEN_A,
-      path: '/content-reader/v1/mcp',
+      token: mcpToken,
+      path: contentReaderPath,
     });
     expect(mcpResponse.status).toBe(200);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   form-data: '>=4.0.6'
   js-yaml: 4.3.1
-  nanoid: 3.3.17
+  nanoid: 3.3.18
   minimatch: '>=5.1.8'
   semver: '>=7.8.4'
   tar: '>=7.5.19'
@@ -1656,8 +1656,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3419,7 +3419,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -3535,7 +3535,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,7 +40,7 @@ minimumReleaseAgeExclude:
 overrides:
   form-data: '>=4.0.6'
   js-yaml: 4.3.1
-  nanoid: 3.3.17
+  nanoid: 3.3.18
   minimatch: '>=5.1.8'
   semver: '>=7.8.4'
   tar: '>=7.5.19'


### PR DESCRIPTION
## Summary

Close **MCP token passthrough** and enforce an explicit dual-leg authorization boundary. This PR does **not** claim full MCP proxy OAuth hardening (confused-deputy consent remains open).

Previously, the broker returned the upstream Lightdash access token unchanged from `/oauth/token`; the MCP resource server then accepted that same bearer and forwarded it to Lightdash. That made a downstream Lightdash credential double as the MCP access token and prevented strict MCP resource/audience binding ([MCP Authorization](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization); [Token Passthrough](https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices#token-passthrough)).

## Changes

- require exactly one RFC 8707 `resource` in MCP authorization requests
- bind the resource to pending authorization state and the one-time broker code
- require the same `resource` again at `/oauth/token`
- stop forwarding the MCP `resource`, PKCE, or MCP scope to the downstream Lightdash OAuth leg
- mint short-lived authenticated-encrypted `ldmcp1.*` MCP access tokens with AES-256-GCM
- derive the token encryption key with domain separation from the server-held Lightdash OAuth client secret (**v1**; dedicated MCP token key is a follow-up)
- bind each MCP token to its DCR client ID, exact profile resource, MCP scope, and expiry
- reject raw Lightdash tokens, tampered tokens, expired tokens, and cross-profile tokens locally before calling Lightdash
- never expose the downstream Lightdash bearer in plaintext/reusable form to the MCP client; it is authenticated-encrypted inside the broker token and recoverable only by the server
- keep MCP scopes separate from any downstream Lightdash token scope (scopes remain client-echo until consent/grant work)
- add [ADR-0026](docs/adr/0026-mcp-oauth-dual-leg-token-boundary.md) (Amends ADR-0007) and update operator / threat-model docs

## Security properties (in scope)

```text
MCP client
    |
    | broker-issued MCP token (audience = exact profile resource)
    v
lightdash-tools MCP server
    |
    | decrypt + validate broker token
    | recover delegated Lightdash credential server-side
    v
Lightdash API
```

Normal MCP profile requests remain stateless across replicas. The existing in-memory DCR/authorization-code handshake still requires sticky `/oauth/*` routing or a single replica while the handshake is in flight.

### Compatibility

This intentionally invalidates previously cached raw Lightdash bearer tokens as MCP credentials. Existing MCP clients must complete the OAuth flow again after deployment so they receive a broker-issued `ldmcp1.*` token.

### Residual risk / follow-up (out of scope here)

This PR fixes **token passthrough** and **MCP resource/audience separation** only.

| Residual | Status |
| --- | --- |
| Confused deputy / per-client consent before static Lightdash redirect | Open — evaluate independently ([MCP Security Best Practices](https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices#confused-deputy-problem)) |
| Per-token MCP revocation store | Not claimed — expiry / upstream revoke / client-secret rotation |
| Dedicated MCP token encryption secret | Follow-up — v1 key derived from Lightdash OAuth client secret |
| Independent MCP max TTL | Follow-up — lifetime currently mirrors Lightdash `expires_in` |
| Broker-owned MCP scope grants | Follow-up — scopes are still echoed from the client authorize request |

## Validation

Added/updated tests for:

- encrypted token round-trip without downstream-token disclosure
- tamper and expiry rejection
- cross-profile audience rejection
- raw Lightdash-token rejection before upstream validation
- authorization/token `resource` binding
- resource mismatch code restoration
- removal of MCP resource/scope passthrough to Lightdash
- downstream credential validation only after broker-token validation
- HTTP integration proving the MCP client bearer is never forwarded to Lightdash
- opaque downstream Lightdash credentials wrapped by broker-issued MCP tokens

## Docs

- [ADR-0026](docs/adr/0026-mcp-oauth-dual-leg-token-boundary.md)
- [docs/operators/mcp-oauth.md](docs/operators/mcp-oauth.md)
- [docs/operators/mcp-oauth-threat-model.md](docs/operators/mcp-oauth-threat-model.md)

## References

- [MCP Authorization 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
- [MCP Security Best Practices: Token Passthrough / Confused Deputy](https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices)
- [RFC 8707 Resource Indicators for OAuth 2.0](https://www.rfc-editor.org/rfc/rfc8707)