### PR TITLE
feat(mcp): host-aware OAuth metadata on extra invoke origins

### DIFF
--- a/.changes/0.17.0.
+++ b/.changes/0.17.0.
@@ -1,0 +1,10 @@
+## [0.17.0] - 2026-08-20
+### Features
+* MCP progressive-disclosure prompt context (compact default; compatible/embedded via LIGHTDASH_TOOLS_MCP_PROMPT_CONTEXT)
+* MCP HTTP OAuth advertises host-aware metadata on extra invoke origins (LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS)
+### Bug Fixes
+* Separate MCP-issued OAuth tokens from Lightdash credentials and canonicalize RFC 8707 resource audiences
+### Documentation
+* Document MCP HTTP health probes (/health/live, /health/ready) in the package README and Cloud Run operator guide.
+### Chores
+* Sync OpenAPI types to Lightdash 1.109.1

--- a/.changes/unreleased/chore-20260810-140854.yaml
+++ b/.changes/unreleased/chore-20260810-140854.yaml
@@ -1,3 +1,0 @@
-kind: chore
-body: Sync OpenAPI types to Lightdash 1.109.1
-time: 2026-08-10T14:08:54.443516192Z

--- a/.changes/unreleased/docs-20260810-111919.yaml
+++ b/.changes/unreleased/docs-20260810-111919.yaml
@@ -1,3 +1,0 @@
-kind: docs
-body: Document MCP HTTP health probes (/health/live, /health/ready) in the package README and Cloud Run operator guide.
-time: 2026-08-10T11:19:19.772527+09:00

--- a/.changes/unreleased/feat-prompt-context.yaml
+++ b/.changes/unreleased/feat-prompt-context.yaml
@@ -1,3 +1,0 @@
-kind: feat
-body: MCP progressive-disclosure prompt context (compact default; compatible/embedded via LIGHTDASH_TOOLS_MCP_PROMPT_CONTEXT)
-time: 2026-08-11T08:40:00Z

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.17.0] - 2026-08-20
+
+### Features
+
+- MCP progressive-disclosure prompt context (compact default; compatible/embedded via LIGHTDASH_TOOLS_MCP_PROMPT_CONTEXT)
+- MCP HTTP OAuth advertises host-aware metadata on extra invoke origins (LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS)
+
+### Bug Fixes
+
+- Separate MCP-issued OAuth tokens from Lightdash credentials and canonicalize RFC 8707 resource audiences
+
+### Documentation
+
+- Document MCP HTTP health probes (/health/live, /health/ready) in the package README and Cloud Run operator guide.
+
+### Chores
+
+- Sync OpenAPI types to Lightdash 1.109.1
+
 ## [0.14.0] - 2026-08-10
 
 ### Features

--- a/docs/adr/0007-mcp-http-transport-auth-modes-sdk-v2.md
+++ b/docs/adr/0007-mcp-http-transport-auth-modes-sdk-v2.md
@@ -10,6 +10,8 @@ Amended by [19. MCP stateless protocol core without Redis ephemeral store](0019-
 
 Amended by [26. MCP OAuth uses a dual-leg, resource-bound token boundary](0026-mcp-oauth-dual-leg-token-boundary.md)
 
+Amended by [27. Extra invoke origins advertise host-aware OAuth metadata](0027-mcp-oauth-extra-invoke-origins.md)
+
 ## Context
 
 `@lightdash-tools/mcp` must serve STDIO (local agents) and Streamable HTTP (remote). Hosted HTTP needs per-user Lightdash identity. Operators register one Lightdash OAuth application per MCP deployment; the **client secret must not** be shipped to Claude Code / Cursor.

--- a/docs/adr/0026-mcp-oauth-dual-leg-token-boundary.md
+++ b/docs/adr/0026-mcp-oauth-dual-leg-token-boundary.md
@@ -6,6 +6,8 @@ Date: 2026-08-17
 
 Accepted
 
+Amended by [27. Extra invoke origins advertise host-aware OAuth metadata](0027-mcp-oauth-extra-invoke-origins.md)
+
 Amends [7. MCP HTTP transport, OAuth broker, SDK v2](0007-mcp-http-transport-auth-modes-sdk-v2.md)
 
 ## Context

--- a/docs/adr/0027-mcp-oauth-extra-invoke-origins.md
+++ b/docs/adr/0027-mcp-oauth-extra-invoke-origins.md
@@ -1,0 +1,63 @@
+# 27. Extra invoke origins advertise host-aware OAuth metadata
+
+Date: 2026-08-20
+
+## Status
+
+Accepted
+
+Amends [7. MCP HTTP transport, OAuth broker, SDK v2](0007-mcp-http-transport-auth-modes-sdk-v2.md)
+
+Amends [26. MCP OAuth uses a dual-leg, resource-bound token boundary](0026-mcp-oauth-dual-leg-token-boundary.md)
+
+## Context
+
+Hosted MCP OAuth binds RFC 8707 `resource`, PRM, and broker AS metadata to `LIGHTDASH_TOOLS_MCP_PUBLIC_URL` ([ADR-0007](0007-mcp-http-transport-auth-modes-sdk-v2.md), [ADR-0026](0026-mcp-oauth-dual-leg-token-boundary.md)). That is correct for public HTTPS clients (Cursor, Claude Code, `@modelcontextprotocol/client` v2).
+
+Private-network clients often reach the same process through an extra hostname (internal HTTP load balancer, private DNS, Kubernetes Service). If PRM still advertises the public issuer, those clients fetch public `/.well-known/oauth-authorization-server` and fail at a public WAF. Pointing `PUBLIC_URL` at the extra origin breaks the Lightdash/Google redirect (HTTPS + public DNS) and the broker issuer. Setting the client Resource URL to the public origin while invoking the extra origin causes resource mismatch.
+
+The extra origin is often cleartext HTTP on a different hostname than `PUBLIC_URL`. Same-hostname private TLS (split-horizon) is preferable when infrastructure can do it; this ADR covers the common case where it cannot.
+
+## Decision
+
+Optional `LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS` lists extra absolute `http(s)` origins (no path). Matching uses the full origin (scheme + host + port; default ports stripped), reconstructed from `Host` and request scheme (`X-Forwarded-Proto`, else TLS, else http). Hostname-only matching is rejected.
+
+When `Host` matches a listed origin:
+
+1. PRM `resource` and `authorization_servers` use that origin.
+2. AS `token_endpoint` and `registration_endpoint` use that origin (`/oauth/token`, `/oauth/register`).
+3. AS `issuer` and `authorization_endpoint` stay on `PUBLIC_URL`.
+4. `/oauth/callback` stays `{PUBLIC_URL}/oauth/callback`.
+5. Bearer `WWW-Authenticate` `resource_metadata` uses the invoke origin.
+6. Broker tokens are bound to `{invokeOrigin}{profilePath}`; RS verify uses the **request Host** profile resource.
+
+Authorize and token still require RFC 8707 `resource` to identify an enabled profile on `PUBLIC_URL` **or** a listed invoke origin. That allows a browser authorize on public HTTPS with `resource` equal to the extra-origin profile URL.
+
+`PUBLIC_URL` remains HTTPS (or loopback HTTP). Extra origins may be non-loopback HTTP. Do not reintroduce `ALLOW_INSECURE_PUBLIC_URL`. Do not set issuer globally to an extra origin.
+
+This is an intentional RFC 8414 issuer/well-known split. `@modelcontextprotocol/client` v2 will reject HTTP invoke origins (`IssuerMismatchError`, `InsecureTokenEndpointError`). Public HTTPS remains the client for that SDK. Private-network clients that POST token/DCR to the extra origin (and leave Resource URL empty so `resource` is the server URL) are the intended consumers.
+
+Host-header spoofing: rewrite only for an **explicit** extra origin. Operators must not route extra-origin Hostnames on the public VIP.
+
+## Consequences
+
+### Positive
+
+- VPC clients can complete per-user OAuth without fetching public well-known through a WAF.
+- Google/Lightdash redirect and JWT-equivalent issuer stay on public HTTPS.
+- Dual-leg resource binding ([ADR-0026](0026-mcp-oauth-dual-leg-token-boundary.md)) still applies; extra origins are additional allowed audiences, not a passthrough.
+- Multiple extra origins work; the feature is not cloud- or client-specific.
+
+### Negative / residual risks
+
+- RFC 8414 issuer echo is split on extra origins. Documented; MCP TypeScript client v2 is unsupported on those URLs.
+- Cleartext token/DCR on extra HTTP origins is accepted for private networks. Restrict ingress; do not expose those Hosts publicly.
+- A public client that can set `Host` to a listed extra origin could receive HTTP token URLs. Mitigate at the load balancer (do not serve extra Hosts on the public VIP).
+- A token minted for an extra-origin resource will not verify on the public Host (and vice versa). Clients must use one resource consistently.
+
+## References
+
+- [RFC 8414 — OAuth 2.0 Authorization Server Metadata](https://www.rfc-editor.org/rfc/rfc8414)
+- [RFC 8707 — Resource Indicators for OAuth 2.0](https://www.rfc-editor.org/rfc/rfc8707)
+- [MCP Authorization specification (2026-07-28)](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
+- Operator notes: `docs/operators/mcp-oauth.md`, `docs/operators/mcp-oauth-threat-model.md`

--- a/docs/adr/0027-mcp-oauth-extra-invoke-origins.md
+++ b/docs/adr/0027-mcp-oauth-extra-invoke-origins.md
@@ -57,7 +57,7 @@ Host-header spoofing: rewrite only for an **explicit** extra origin. Operators m
 
 ## References
 
-- [RFC 8414 — OAuth 2.0 Authorization Server Metadata](https://www.rfc-editor.org/rfc/rfc8414)
-- [RFC 8707 — Resource Indicators for OAuth 2.0](https://www.rfc-editor.org/rfc/rfc8707)
+- [RFC 8414 — OAuth 2.0 Authorization Server Metadata](https://www.rfc-editor.org/rfc/rfc8414.html)
+- [RFC 8707 — Resource Indicators for OAuth 2.0](https://www.rfc-editor.org/rfc/rfc8707.html)
 - [MCP Authorization specification (2026-07-28)](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
 - Operator notes: `docs/operators/mcp-oauth.md`, `docs/operators/mcp-oauth-threat-model.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,5 +46,6 @@ Vocabulary: living product term is **profile**. The MCP protocol uses Host / Cli
 23. [MCP HTTP profile mount allowlist via env](0024-mcp-http-profile-mount-allowlist-via-env.md)
 24. [MCP progressive-disclosure prompt context policies](0025-mcp-progressive-disclosure-prompt-context-policies.md)
 25. [MCP OAuth uses a dual-leg, resource-bound token boundary](0026-mcp-oauth-dual-leg-token-boundary.md)
+26. [Extra invoke origins advertise host-aware OAuth metadata](0027-mcp-oauth-extra-invoke-origins.md)
 
 Number **16** is unused in the binding set (former pluggable Redis/ephemeral store; superseded by 0019).

--- a/docs/operators/cursor-claude.md
+++ b/docs/operators/cursor-claude.md
@@ -37,6 +37,8 @@ MCP    → Lightdash API with same Bearer token
 
 Replace the host with your `LIGHTDASH_TOOLS_MCP_PUBLIC_URL`. Path is profile-owned: `/semantic-layer/v1/mcp`.
 
+Private-network clients on an extra invoke origin are a different contract — see [mcp-oauth.md](mcp-oauth.md#extra-invoke-origins-private-load-balancer--internal-dns). Cursor / Claude Code should keep using public HTTPS.
+
 **Do not** put `LIGHTDASH_TOOLS_OAUTH_CLIENT_ID` / `_SECRET` (or any Lightdash client secret) in Cursor or Claude Code config.
 
 ## Local smoke (Cloudflare Tunnel)

--- a/docs/operators/mcp-oauth-threat-model.md
+++ b/docs/operators/mcp-oauth-threat-model.md
@@ -1,6 +1,6 @@
 # Threat model: OAuth-backed Streamable HTTP MCP
 
-Security analysis for hosted `@lightdash-tools/mcp` with the **dual-leg OAuth broker** (server-held Lightdash confidential client + broker-issued MCP access tokens). Architecture: [ADR-0007](../adr/0007-mcp-http-transport-auth-modes-sdk-v2.md) as amended by [ADR-0026](../adr/0026-mcp-oauth-dual-leg-token-boundary.md). Protocol: [MCP Authorization 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization). Security guidance: [MCP Security Best Practices](https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices).
+Security analysis for hosted `@lightdash-tools/mcp` with the **dual-leg OAuth broker** (server-held Lightdash confidential client + broker-issued MCP access tokens). Architecture: [ADR-0007](../adr/0007-mcp-http-transport-auth-modes-sdk-v2.md) as amended by [ADR-0026](../adr/0026-mcp-oauth-dual-leg-token-boundary.md) and [ADR-0027](../adr/0027-mcp-oauth-extra-invoke-origins.md). Protocol: [MCP Authorization 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization). Security guidance: [MCP Security Best Practices](https://modelcontextprotocol.io/docs/2026-07-28/tutorials/security/security_best_practices).
 
 ## Assets
 
@@ -27,7 +27,9 @@ Security analysis for hosted `@lightdash-tools/mcp` with the **dual-leg OAuth br
 | No per-token MCP revocation                     | Medium | Self-contained broker tokens stop on expiry, upstream Lightdash revocation, or OAuth client-secret rotation. Opaque shared token store is out of scope (conflicts with ADR-0019 unless product requires revoke).                                                                                       |
 | Token leakage in logs                           | High   | Redact `Authorization` in reverse proxies and platform logs. Never log raw tokens or client secret. Audit entries use token hash only.                                                                                                                                                                 |
 | Token/session confusion                         | High   | Bind sessions to `userUuid` and `organizationUuid`; reject subject or organization mismatch on resume.                                                                                                                                                                                                 |
-| OAuth metadata spoofing (wrong public URL)      | Medium | Require `LIGHTDASH_TOOLS_MCP_PUBLIC_URL`. Normalize URL. PRM `authorization_servers` = public MCP host (broker), not Lightdash directly.                                                                                                                                                               |
+| OAuth metadata spoofing (wrong public URL)      | Medium | Require `LIGHTDASH_TOOLS_MCP_PUBLIC_URL`. Normalize URL. PRM `authorization_servers` = public MCP host (broker), not Lightdash directly. Extra `INVOKE_ORIGINS` rewrite metadata only when `Host` matches an explicit listed origin.                                                                   |
+| Extra-origin Host spoofing on the public VIP    | Medium | Rewrite PRM/token/DCR only for listed origins. Do not route extra-origin Hostnames on the public VIP. Cleartext HTTP extra origins are for private networks; `@modelcontextprotocol/client` v2 is unsupported there ([ADR-0027](../adr/0027-mcp-oauth-extra-invoke-origins.md)).                       |
+| Spoofed `X-Forwarded-Proto` on extra origins    | Medium | Scheme is part of origin match. Trust `X-Forwarded-Proto` only from the private proxy that terminates the extra hostname; strip or overwrite it on the public VIP. A client that can set both `Host` and proto to a listed HTTP origin gets HTTP token/DCR URLs.                                       |
 | Reimplemented RBAC mismatch                     | High   | Do not recreate Lightdash object-level permissions in MCP. Delegate to Lightdash API with the recovered downstream credential after broker-token validation.                                                                                                                                           |
 | Agent destructive actions                       | High   | Profile `tools` mounts fix the MCP catalog (ADR-0006 / ADR-0022; [ADR-0008](../adr/0008-mcp-request-scope-and-hardening.md)); shipped `semantic-layer` profile is discovery/compile only; irrecoverable ops are client-only per [ADR-0004](../adr/0004-agent-safe-exposure-mcp-cli-vs-client-only.md). |
 | CSRF / browser-origin misuse                    | Medium | Bearer tokens in `Authorization` header only. Optional `LIGHTDASH_TOOLS_MCP_ALLOWED_ORIGINS`. No cookie-based MCP auth.                                                                                                                                                                                |
@@ -38,6 +40,7 @@ Security analysis for hosted `@lightdash-tools/mcp` with the **dual-leg OAuth br
 ### Server configuration
 
 - [ ] Set `LIGHTDASH_URL`, `LIGHTDASH_TOOLS_MCP_PUBLIC_URL`, `LIGHTDASH_TOOLS_OAUTH_CLIENT_ID`, `LIGHTDASH_TOOLS_OAUTH_CLIENT_SECRET`.
+- [ ] If VPC clients use an extra hostname: set `LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS` (do not point `PUBLIC_URL` at that origin; do not serve that Host on the public VIP).
 - [ ] Register exactly one Lightdash redirect URI: `{PUBLIC_URL}/oauth/callback`.
 - [ ] Confirm deployed profile URL matches intended capability (shipped `semantic-layer` = discovery/compile only; ADR-0006).
 - [ ] Pin project via client/gateway `X-Lightdash-Project` when operators need a per-request project, and/or set `LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS` for a process-level hard allowlist ([ADR-0008](../adr/0008-mcp-request-scope-and-hardening.md)).
@@ -91,6 +94,7 @@ Security analysis for hosted `@lightdash-tools/mcp` with the **dual-leg OAuth br
 
 - [mcp-oauth.md](mcp-oauth.md) — setup and troubleshooting
 - [ADR-0026](../adr/0026-mcp-oauth-dual-leg-token-boundary.md) — dual-leg token boundary
+- [ADR-0027](../adr/0027-mcp-oauth-extra-invoke-origins.md) — extra invoke origins
 - [cursor-claude.md](cursor-claude.md) — Cursor client setup
 - [cloud-run.md](cloud-run.md) — Cloud Run deployment
 - [agent-context.md](agent-context.md) — agent guardrail invariants

--- a/docs/operators/mcp-oauth.md
+++ b/docs/operators/mcp-oauth.md
@@ -1,18 +1,18 @@
 # OAuth-backed Streamable HTTP MCP
 
-Operator guide for hosted `@lightdash-tools/mcp` with a **server-held Lightdash OAuth application** (confidential client + dual-leg broker). Architecture: [ADR-0007](../adr/0007-mcp-http-transport-auth-modes-sdk-v2.md) as amended by [ADR-0026](../adr/0026-mcp-oauth-dual-leg-token-boundary.md). Protocol: [MCP Authorization 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization). Threat model: [mcp-oauth-threat-model.md](mcp-oauth-threat-model.md).
+Operator guide for hosted `@lightdash-tools/mcp` with a **server-held Lightdash OAuth application** (confidential client + dual-leg broker). Architecture: [ADR-0007](../adr/0007-mcp-http-transport-auth-modes-sdk-v2.md) as amended by [ADR-0026](../adr/0026-mcp-oauth-dual-leg-token-boundary.md) and [ADR-0027](../adr/0027-mcp-oauth-extra-invoke-origins.md). Protocol: [MCP Authorization 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization). Threat model: [mcp-oauth-threat-model.md](mcp-oauth-threat-model.md).
 
 ## Mental model
 
-| Role                                   | Who                                                                                       |
-| :------------------------------------- | :---------------------------------------------------------------------------------------- |
-| Lightdash OAuth app (client id/secret) | **MCP server** env (downstream confidential client)                                       |
-| Redirect URI (one, shared)             | `{PUBLIC_URL}/oauth/callback`                                                             |
-| AS façade for MCP clients              | MCP host (`/oauth/*`, PRM `authorization_servers` = `PUBLIC_URL`)                         |
-| MCP access token                       | Broker-issued `ldmcp1.*` AEAD bearer; audience = exact enabled profile resource           |
-| Downstream Lightdash credential        | Recovered server-side from the broker token only; never returned as the MCP client bearer |
-| Resource servers                       | Profile paths (`/semantic-layer/v1/mcp`, …)                                               |
-| MCP clients (Claude Code / Cursor)     | **URL only** — no client secret                                                           |
+| Role                                   | Who                                                                                                              |
+| :------------------------------------- | :--------------------------------------------------------------------------------------------------------------- |
+| Lightdash OAuth app (client id/secret) | **MCP server** env (downstream confidential client)                                                              |
+| Redirect URI (one, shared)             | `{PUBLIC_URL}/oauth/callback`                                                                                    |
+| AS façade for MCP clients              | MCP host (`/oauth/*`, PRM `authorization_servers` = `PUBLIC_URL`, or an extra invoke origin when `Host` matches) |
+| MCP access token                       | Broker-issued `ldmcp1.*` AEAD bearer; audience = exact enabled profile resource                                  |
+| Downstream Lightdash credential        | Recovered server-side from the broker token only; never returned as the MCP client bearer                        |
+| Resource servers                       | Profile paths (`/semantic-layer/v1/mcp`, …)                                                                      |
+| MCP clients (Claude Code / Cursor)     | **URL only** — no client secret                                                                                  |
 
 Auth mode is **inferred** from credentials (no `LIGHTDASH_TOOLS_MCP_AUTH_MODE`).
 
@@ -80,6 +80,32 @@ curl -s "https://lightdash-mcp.example.com/.well-known/oauth-authorization-serve
 
 MCP endpoint: `POST/GET/DELETE /semantic-layer/v1/mcp`.
 
+## Extra invoke origins (private load balancer / internal DNS)
+
+Optional. Use when VPC clients reach the same process on a **different** origin than `PUBLIC_URL` (internal HTTP LB, private DNS, Kubernetes Service) and must not fetch public well-known through a WAF.
+
+Do **not** point `LIGHTDASH_TOOLS_MCP_PUBLIC_URL` at the extra origin. Prefer same-hostname private TLS when you can; this env covers extra hostnames, including cleartext HTTP.
+
+```bash
+export LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS="http://mcp.ilb.internal"
+```
+
+Comma-separated absolute `http(s)` origins, no path. Invalid values fail OAuth startup. Matching is the full origin (scheme + host + port), not hostname alone. Scheme comes from `X-Forwarded-Proto` (first value), else TLS, else `http` — set the env origin to the scheme clients use, and make sure the proxy forwards that proto.
+
+On a matching `Host`:
+
+- PRM `resource` / `authorization_servers` and AS `token_endpoint` / `registration_endpoint` use the extra origin
+- AS `issuer`, `/oauth/authorize`, and `/oauth/callback` stay on `PUBLIC_URL`
+- Broker tokens are bound to `{invokeOrigin}{profilePath}`
+
+Client contract for those origins:
+
+- Server URL = extra origin + profile path (for example `http://mcp.ilb.internal/semantic-layer/v1/mcp`)
+- Resource URL **empty** (the server URL becomes RFC 8707 `resource`). A public Resource URL causes mismatch
+- Enable DCR if the client requires `/oauth/register`
+
+`@modelcontextprotocol/client` **v2** will reject HTTP invoke origins (`IssuerMismatchError`, `InsecureTokenEndpointError`). Point that SDK at public HTTPS. Do not serve extra-origin Hostnames on the public VIP.
+
 ## Secondary: PAT / local
 
 | Use                        | Env                                       |
@@ -114,6 +140,7 @@ After deploying the dual-leg broker, re-run the client OAuth login so cached raw
 | :------------------------------------ | :------------------------------------------------------------------------ |
 | `LIGHTDASH_URL`                       | Lightdash instance                                                        |
 | `LIGHTDASH_TOOLS_MCP_PUBLIC_URL`      | Public base URL (required for OAuth)                                      |
+| `LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS`  | Optional extra invoke origins (comma-separated; host-aware PRM/token/DCR) |
 | `LIGHTDASH_TOOLS_OAUTH_CLIENT_ID`     | Server-held Lightdash app client id                                       |
 | `LIGHTDASH_TOOLS_OAUTH_CLIENT_SECRET` | Server-held Lightdash app client secret (also derives MCP token AEAD key) |
 | `LIGHTDASH_TOOLS_MCP_SHARED_KEY`      | Secondary shared-key gateway                                              |
@@ -129,19 +156,20 @@ CLI-only (ignored for MCP auth): `LIGHTDASH_TOOLS_SAFETY_MODE`, `DRY_RUN`. Share
 
 ## Broker routes
 
-| Path                                      | Purpose                                                                           |
-| :---------------------------------------- | :-------------------------------------------------------------------------------- |
-| `/oauth/authorize`                        | Start client OAuth; require `resource`; redirect to Lightdash with fixed callback |
-| `/oauth/callback`                         | Lightdash redirect; exchange code with client secret                              |
-| `/oauth/token`                            | PKCE + same `resource`; mint `ldmcp1.*` MCP access token                          |
-| `/oauth/register`                         | Thin DCR stub (public client)                                                     |
-| `/.well-known/oauth-authorization-server` | Broker AS metadata                                                                |
-| `/.well-known/oauth-protected-resource`   | PRM (`authorization_servers` = `PUBLIC_URL`)                                      |
-| `/health/live`, `/health/ready`           | Unauthenticated process probes (not OAuth; see [cloud-run.md](cloud-run.md))      |
+| Path                                      | Purpose                                                                                                    |
+| :---------------------------------------- | :--------------------------------------------------------------------------------------------------------- |
+| `/oauth/authorize`                        | Start client OAuth; require `resource`; redirect to Lightdash with fixed callback                          |
+| `/oauth/callback`                         | Lightdash redirect; exchange code with client secret                                                       |
+| `/oauth/token`                            | PKCE + same `resource`; mint `ldmcp1.*` MCP access token                                                   |
+| `/oauth/register`                         | Thin DCR stub (public client)                                                                              |
+| `/.well-known/oauth-authorization-server` | Broker AS metadata (token/DCR URLs follow `Host` when it matches `INVOKE_ORIGINS`)                         |
+| `/.well-known/oauth-protected-resource`   | PRM (`authorization_servers` = request origin when Host matches an extra invoke origin; else `PUBLIC_URL`) |
+| `/health/live`, `/health/ready`           | Unauthenticated process probes (not OAuth; see [cloud-run.md](cloud-run.md))                               |
 
 ## Related
 
 - [ADR-0026 — dual-leg MCP OAuth token boundary](../adr/0026-mcp-oauth-dual-leg-token-boundary.md)
+- [ADR-0027 — extra invoke origins](../adr/0027-mcp-oauth-extra-invoke-origins.md)
 - [cursor-claude.md](cursor-claude.md)
 - [cloud-run.md](cloud-run.md)
 - [mcp-oauth-threat-model.md](mcp-oauth-threat-model.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools",
-  "version": "0.14.0",
+  "version": "0.17.0",
   "private": true,
   "description": "",
   "keywords": [],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/cli",
-  "version": "0.14.0",
+  "version": "0.17.0",
   "description": "CLI for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,7 +35,7 @@ const program = new Command();
 program
   .name('lightdash-ai')
   .description('CLI for Lightdash AI')
-  .version('0.14.0')
+  .version('0.17.0')
   .option(
     '--safety-mode <mode>',
     'Safety mode (read-only, write-idempotent, write-destructive)',

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/client",
-  "version": "0.14.0",
+  "version": "0.17.0",
   "description": "Client library for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/common",
-  "version": "0.14.0",
+  "version": "0.17.0",
   "description": "Shared utilities and types for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -96,13 +96,23 @@ Do **not** set OAuth client secrets for stdio. MCP ignores CLI `SAFETY_MODE` / `
 
 ### HTTP OAuth (primary)
 
-| Required                                                                                                                    | Common optional                                                                                                                                               |
-| :-------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `LIGHTDASH_URL`, `LIGHTDASH_TOOLS_MCP_PUBLIC_URL`, `LIGHTDASH_TOOLS_OAUTH_CLIENT_ID`, `LIGHTDASH_TOOLS_OAUTH_CLIENT_SECRET` | port, `ALLOWED_ORIGINS`, [`LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS`](#project-allowlist), [`LIGHTDASH_TOOLS_MCP_PROFILES`](#profile-allowlist), token cache TTL |
+| Required                                                                                                                    | Common optional                                                                                                                                                                                                              |
+| :-------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LIGHTDASH_URL`, `LIGHTDASH_TOOLS_MCP_PUBLIC_URL`, `LIGHTDASH_TOOLS_OAUTH_CLIENT_ID`, `LIGHTDASH_TOOLS_OAUTH_CLIENT_SECRET` | port, `ALLOWED_ORIGINS`, [`LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS`](#extra-invoke-origins), [`LIGHTDASH_TOOLS_ALLOWED_PROJECT_UUIDS`](#project-allowlist), [`LIGHTDASH_TOOLS_MCP_PROFILES`](#profile-allowlist), token cache TTL |
 
 On Cloud Run / hosted HTTP, leave `LIGHTDASH_TOOLS_AUDIT_LOG` unset — tool audits are stderr JSON (`channel: "audit"`) → Cloud Logging. See [cloud-run.md](../../docs/operators/cloud-run.md).
 
 Register Lightdash redirect URI: `{PUBLIC_URL}/oauth/callback`. Clients connect with URL only to a profile path above. Protocol: [MCP Authorization 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization).
+
+### Extra invoke origins
+
+Optional private-network hostnames (internal LB, internal DNS) that should advertise their own PRM and token/DCR while Google authorize/callback stay on `PUBLIC_URL`. See [mcp-oauth.md](../../docs/operators/mcp-oauth.md#extra-invoke-origins-private-load-balancer--internal-dns) and [ADR-0027](../../docs/adr/0027-mcp-oauth-extra-invoke-origins.md).
+
+```bash
+export LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS="http://mcp.ilb.internal"
+```
+
+On those Hosts, leave the client Resource URL empty. Do not point `@modelcontextprotocol/client` v2 at an HTTP extra origin — use public HTTPS.
 
 ### Content-developer / content-governance signing
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/mcp",
-  "version": "0.14.0",
+  "version": "0.17.0",
   "description": "MCP server for Lightdash semantic-layer, organization-audit, content-reader, content-developer, content-governance, and ai-agent-ops profiles.",
   "keywords": [],
   "repository": {

--- a/packages/mcp/src/auth/oauth-broker/as-metadata.ts
+++ b/packages/mcp/src/auth/oauth-broker/as-metadata.ts
@@ -14,16 +14,21 @@ export interface AuthorizationServerMetadata {
   scopes_supported: string[];
 }
 
-/** RFC 8414 metadata for the MCP-hosted OAuth broker (issuer = PUBLIC_URL). */
+/**
+ * RFC 8414 metadata for the MCP-hosted OAuth broker (issuer = PUBLIC_URL).
+ * On an extra invoke origin, token/DCR URLs move to that origin; issuer and
+ * authorize stay on PUBLIC_URL (intentional RFC 8414 split).
+ */
 export function buildBrokerAuthorizationServerMetadata(
   config: McpHttpConfig,
+  tokenOrigin: string,
 ): AuthorizationServerMetadata {
   const issuer = requirePublicUrl(config, 'authorization server metadata');
   return {
     issuer,
     authorization_endpoint: `${issuer}${OAUTH_AUTHORIZE_PATH}`,
-    token_endpoint: `${issuer}${OAUTH_TOKEN_PATH}`,
-    registration_endpoint: `${issuer}${OAUTH_REGISTER_PATH}`,
+    token_endpoint: `${tokenOrigin}${OAUTH_TOKEN_PATH}`,
+    registration_endpoint: `${tokenOrigin}${OAUTH_REGISTER_PATH}`,
     response_types_supported: ['code'],
     grant_types_supported: ['authorization_code'],
     code_challenge_methods_supported: ['S256'],

--- a/packages/mcp/src/auth/oauth-broker/invoke-origins.test.ts
+++ b/packages/mcp/src/auth/oauth-broker/invoke-origins.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  allowedResourceOrigins,
   matchInvokeOrigin,
   originFromHostHeader,
   parseInvokeOrigins,
   requestProtocol,
+  resourceOriginForRequest,
 } from './invoke-origins.js';
 
 import type { IncomingMessage } from 'node:http';
@@ -105,5 +107,20 @@ describe('requestProtocol', () => {
         socket: {},
       } as unknown as IncomingMessage),
     ).toBe('http');
+  });
+});
+
+describe('allowedResourceOrigins / resourceOriginForRequest', () => {
+  it('strips a default port from the configured public URL', () => {
+    expect(allowedResourceOrigins('https://mcp.example.com:443', [])).toEqual([
+      'https://mcp.example.com',
+    ]);
+    expect(
+      resourceOriginForRequest(
+        { headers: { host: 'mcp.example.com' }, socket: {} } as unknown as IncomingMessage,
+        [],
+        'https://mcp.example.com:443',
+      ),
+    ).toBe('https://mcp.example.com');
   });
 });

--- a/packages/mcp/src/auth/oauth-broker/invoke-origins.test.ts
+++ b/packages/mcp/src/auth/oauth-broker/invoke-origins.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  matchInvokeOrigin,
+  originFromHostHeader,
+  parseInvokeOrigins,
+  requestProtocol,
+} from './invoke-origins.js';
+
+import type { IncomingMessage } from 'node:http';
+
+const ILB = 'http://mcp.ilb.internal';
+
+describe('parseInvokeOrigins', () => {
+  it('returns empty when unset or blank', () => {
+    expect(parseInvokeOrigins(undefined, 'https://mcp.example.com')).toEqual([]);
+    expect(parseInvokeOrigins('  ', 'https://mcp.example.com')).toEqual([]);
+  });
+
+  it('parses comma-separated http(s) origins and skips the public URL', () => {
+    const parsed = parseInvokeOrigins(
+      ` ${ILB}, https://mcp.example.com, http://other.internal:8080 `,
+      'https://mcp.example.com',
+    );
+    expect(parsed.map((origin) => origin.origin)).toEqual([
+      'http://mcp.ilb.internal',
+      'http://other.internal:8080',
+    ]);
+  });
+
+  it('strips default ports so http://host:80 matches http://host', () => {
+    const parsed = parseInvokeOrigins('http://mcp.ilb.internal:80', 'https://mcp.example.com');
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]!.origin).toBe(ILB);
+  });
+
+  it('rejects a path, query, fragment, or non-http scheme', () => {
+    expect(() =>
+      parseInvokeOrigins('http://mcp.ilb.internal/v1', 'https://mcp.example.com'),
+    ).toThrow(/without a path/);
+    expect(() => parseInvokeOrigins('not-a-url', 'https://mcp.example.com')).toThrow(
+      /absolute http\(s\) origins/,
+    );
+    expect(() => parseInvokeOrigins('ftp://mcp.ilb.internal', 'https://mcp.example.com')).toThrow(
+      /absolute http\(s\) origins/,
+    );
+  });
+});
+
+describe('originFromHostHeader / matchInvokeOrigin', () => {
+  const invokeOrigins = parseInvokeOrigins(ILB, 'https://mcp.example.com');
+
+  it('matches Host + http scheme to the listed origin', () => {
+    expect(matchInvokeOrigin('mcp.ilb.internal', 'http', invokeOrigins)?.origin).toBe(ILB);
+  });
+
+  it('does not match the same hostname on a different port', () => {
+    expect(matchInvokeOrigin('mcp.ilb.internal:9999', 'http', invokeOrigins)).toBeUndefined();
+  });
+
+  it('does not match https when the listed origin is http', () => {
+    expect(matchInvokeOrigin('mcp.ilb.internal', 'https', invokeOrigins)).toBeUndefined();
+  });
+
+  it('does not match the public hostname', () => {
+    expect(matchInvokeOrigin('mcp.example.com', 'https', invokeOrigins)).toBeUndefined();
+  });
+
+  it('does not parse Host when the extra-origin list is empty', () => {
+    expect(matchInvokeOrigin('mcp.ilb.internal', 'http', [])).toBeUndefined();
+  });
+
+  it('treats non-https protocol as http', () => {
+    expect(originFromHostHeader('mcp.ilb.internal', 'http')?.origin).toBe(ILB);
+    expect(originFromHostHeader('mcp.ilb.internal', 'bogus')?.origin).toBe(ILB);
+  });
+});
+
+describe('requestProtocol', () => {
+  it('prefers the first X-Forwarded-Proto value', () => {
+    expect(
+      requestProtocol({
+        headers: { 'x-forwarded-proto': 'https, http' },
+        socket: {},
+      } as unknown as IncomingMessage),
+    ).toBe('https');
+    expect(
+      requestProtocol({
+        headers: { 'x-forwarded-proto': 'http' },
+        socket: { encrypted: true },
+      } as unknown as IncomingMessage),
+    ).toBe('http');
+  });
+
+  it('falls back to TLS then http', () => {
+    expect(
+      requestProtocol({
+        headers: {},
+        socket: { encrypted: true },
+      } as unknown as IncomingMessage),
+    ).toBe('https');
+    expect(
+      requestProtocol({
+        headers: {},
+        socket: {},
+      } as unknown as IncomingMessage),
+    ).toBe('http');
+  });
+});

--- a/packages/mcp/src/auth/oauth-broker/invoke-origins.ts
+++ b/packages/mcp/src/auth/oauth-broker/invoke-origins.ts
@@ -116,7 +116,7 @@ function matchInvokeOriginFromRequest(
 }
 
 export function allowedResourceOrigins(publicUrl: string, invokeOrigins: readonly URL[]): string[] {
-  return [publicUrl, ...invokeOrigins.map((origin) => origin.origin)];
+  return [new URL(publicUrl).origin, ...invokeOrigins.map((origin) => origin.origin)];
 }
 
 /** Public URL, or a matching extra invoke origin, with no trailing slash. */
@@ -129,5 +129,5 @@ export function resourceOriginForRequest(
   if (invoke !== undefined) {
     return invoke.origin;
   }
-  return publicUrl;
+  return new URL(publicUrl).origin;
 }

--- a/packages/mcp/src/auth/oauth-broker/invoke-origins.ts
+++ b/packages/mcp/src/auth/oauth-broker/invoke-origins.ts
@@ -1,0 +1,133 @@
+import { ENV_LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS } from '../../config/env.js';
+
+import type { IncomingMessage } from 'node:http';
+
+const INVOKE_ORIGIN_ABSOLUTE_ERROR = `${ENV_LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS} entries must be absolute http(s) origins`;
+
+function parseOneInvokeOrigin(raw: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(`${INVOKE_ORIGIN_ABSOLUTE_ERROR} (got ${raw})`);
+  }
+  if (
+    (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') ||
+    parsed.username !== '' ||
+    parsed.password !== ''
+  ) {
+    throw new Error(`${INVOKE_ORIGIN_ABSOLUTE_ERROR} (got ${raw})`);
+  }
+  if (parsed.pathname !== '/' || parsed.search !== '' || parsed.hash !== '') {
+    throw new Error(
+      `${ENV_LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS} entries must be origins without a path, query, or fragment (got ${raw})`,
+    );
+  }
+  return new URL(parsed.origin);
+}
+
+function firstForwardedProto(req: IncomingMessage): string | undefined {
+  const raw = req.headers['x-forwarded-proto'];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (value === undefined || value.length === 0) {
+    return undefined;
+  }
+  return value.split(',')[0]?.trim().toLowerCase();
+}
+
+/**
+ * Request scheme for origin matching. `X-Forwarded-Proto` wins (first value),
+ * then TLS socket, otherwise http. Non-https is treated as http.
+ */
+export function requestProtocol(req: IncomingMessage): 'http' | 'https' {
+  const forwarded = firstForwardedProto(req);
+  if (forwarded === 'https') {
+    return 'https';
+  }
+  if (forwarded === 'http') {
+    return 'http';
+  }
+  return 'encrypted' in req.socket && req.socket.encrypted === true ? 'https' : 'http';
+}
+
+export function originFromHostHeader(
+  hostHeader: string | undefined,
+  protocol: string,
+): URL | undefined {
+  if (hostHeader === undefined || hostHeader.length === 0) {
+    return undefined;
+  }
+  try {
+    return new URL(`${protocol === 'https' ? 'https' : 'http'}://${hostHeader}`);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Extra MCP invoke origins (private load balancer, internal DNS, etc.).
+ * Duplicates of `publicUrl` are skipped.
+ */
+export function parseInvokeOrigins(raw: string | undefined, publicUrl?: string): URL[] {
+  if (raw === undefined || raw.trim() === '') {
+    return [];
+  }
+
+  const seen = new Set<string>();
+  if (publicUrl !== undefined && publicUrl.length > 0) {
+    seen.add(new URL(publicUrl).origin);
+  }
+
+  const parsed: URL[] = [];
+  for (const part of raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)) {
+    const origin = parseOneInvokeOrigin(part);
+    if (seen.has(origin.origin)) {
+      continue;
+    }
+    seen.add(origin.origin);
+    parsed.push(origin);
+  }
+  return parsed;
+}
+
+export function matchInvokeOrigin(
+  hostHeader: string | undefined,
+  protocol: string,
+  invokeOrigins: readonly URL[],
+): URL | undefined {
+  if (invokeOrigins.length === 0) {
+    return undefined;
+  }
+  const fromHost = originFromHostHeader(hostHeader, protocol);
+  if (fromHost === undefined) {
+    return undefined;
+  }
+  return invokeOrigins.find((origin) => origin.origin === fromHost.origin);
+}
+
+function matchInvokeOriginFromRequest(
+  req: IncomingMessage,
+  invokeOrigins: readonly URL[],
+): URL | undefined {
+  return matchInvokeOrigin(req.headers.host, requestProtocol(req), invokeOrigins);
+}
+
+export function allowedResourceOrigins(publicUrl: string, invokeOrigins: readonly URL[]): string[] {
+  return [publicUrl, ...invokeOrigins.map((origin) => origin.origin)];
+}
+
+/** Public URL, or a matching extra invoke origin, with no trailing slash. */
+export function resourceOriginForRequest(
+  req: IncomingMessage,
+  invokeOrigins: readonly URL[],
+  publicUrl: string,
+): string {
+  const invoke = matchInvokeOriginFromRequest(req, invokeOrigins);
+  if (invoke !== undefined) {
+    return invoke.origin;
+  }
+  return publicUrl;
+}

--- a/packages/mcp/src/auth/oauth-broker/routes.test.ts
+++ b/packages/mcp/src/auth/oauth-broker/routes.test.ts
@@ -79,6 +79,7 @@ function mockReq(
   url: string,
   body?: string,
   contentType = 'application/x-www-form-urlencoded',
+  extraHeaders?: Record<string, string>,
 ): IncomingMessage {
   const req = new EventEmitter() as EventEmitter & IncomingMessage;
   req.method = method;
@@ -86,6 +87,7 @@ function mockReq(
   req.headers = {
     host: 'mcp.example.com',
     ...(body !== undefined ? { 'content-type': contentType } : {}),
+    ...extraHeaders,
   };
   queueMicrotask(() => {
     if (body !== undefined) {
@@ -125,11 +127,51 @@ describe('oauth broker helpers', () => {
   });
 
   it('publishes AS metadata pointing at broker endpoints', () => {
-    const metadata = buildBrokerAuthorizationServerMetadata(baseConfig());
+    const metadata = buildBrokerAuthorizationServerMetadata(
+      baseConfig(),
+      'https://mcp.example.com',
+    );
     expect(metadata.issuer).toBe('https://mcp.example.com');
     expect(metadata.authorization_endpoint).toBe('https://mcp.example.com/oauth/authorize');
     expect(metadata.token_endpoint).toBe('https://mcp.example.com/oauth/token');
     expect(metadata.registration_endpoint).toBe('https://mcp.example.com/oauth/register');
+  });
+
+  it('moves token and DCR onto an extra invoke origin while issuer stays public', () => {
+    const metadata = buildBrokerAuthorizationServerMetadata(
+      baseConfig(),
+      'http://mcp.ilb.internal',
+    );
+    expect(metadata.issuer).toBe('https://mcp.example.com');
+    expect(metadata.authorization_endpoint).toBe('https://mcp.example.com/oauth/authorize');
+    expect(metadata.token_endpoint).toBe('http://mcp.ilb.internal/oauth/token');
+    expect(metadata.registration_endpoint).toBe('http://mcp.ilb.internal/oauth/register');
+  });
+
+  it('serves host-aware AS metadata when Host matches an extra invoke origin', async () => {
+    const broker = createOAuthBroker(
+      baseConfig({ invokeOrigins: [new URL('http://mcp.ilb.internal')] }),
+    );
+    const res = mockRes();
+    await broker.handle(
+      mockReq('GET', '/.well-known/oauth-authorization-server', undefined, undefined, {
+        host: 'mcp.ilb.internal',
+        'x-forwarded-proto': 'http',
+      }),
+      res,
+      '/.well-known/oauth-authorization-server',
+    );
+    expect(res.statusCode).toBe(200);
+    const body = res.body as {
+      issuer: string;
+      authorization_endpoint: string;
+      token_endpoint: string;
+      registration_endpoint: string;
+    };
+    expect(body.issuer).toBe('https://mcp.example.com');
+    expect(body.authorization_endpoint).toBe('https://mcp.example.com/oauth/authorize');
+    expect(body.token_endpoint).toBe('http://mcp.ilb.internal/oauth/token');
+    expect(body.registration_endpoint).toBe('http://mcp.ilb.internal/oauth/register');
   });
 
   it('verifies S256 PKCE and rejects PLAIN', () => {
@@ -333,6 +375,67 @@ describe('oauth broker DCR + authorize binding', () => {
     );
     expect(wrongRes.statusCode).toBe(400);
     expect((wrongRes.body as { error: string }).error).toBe('invalid_target');
+  });
+
+  it('accepts an extra invoke-origin profile resource at authorize', async () => {
+    const invokeResource = 'http://mcp.ilb.internal/semantic-layer/v1/mcp';
+    const broker = createOAuthBroker(
+      baseConfig({ invokeOrigins: [new URL('http://mcp.ilb.internal')] }),
+    );
+    const redirectUri = 'http://127.0.0.1:8787/callback';
+    const registerRes = mockRes();
+    await broker.handle(
+      mockReq('POST', '/oauth/register', `redirect_uris=${encodeURIComponent(redirectUri)}`),
+      registerRes,
+      '/oauth/register',
+    );
+    const { client_id: clientId } = registerRes.body as { client_id: string };
+    const challenge = createHash('sha256').update('verifier').digest('base64url');
+
+    const authorizeRes = mockRes();
+    await broker.handle(
+      mockReq(
+        'GET',
+        authorizeUrl(clientId, redirectUri, challenge).replace(
+          encodeURIComponent(RESOURCE),
+          encodeURIComponent(invokeResource),
+        ),
+      ),
+      authorizeRes,
+      '/oauth/authorize',
+    );
+    expect(authorizeRes.statusCode).toBe(302);
+    expect(String(authorizeRes.headers.Location)).toContain('/api/v1/oauth/authorize');
+  });
+
+  it('accepts an extra invoke-origin resource that includes a default port', async () => {
+    const invokeResource = 'http://mcp.ilb.internal:80/semantic-layer/v1/mcp';
+    const broker = createOAuthBroker(
+      baseConfig({ invokeOrigins: [new URL('http://mcp.ilb.internal')] }),
+    );
+    const redirectUri = 'http://127.0.0.1:8787/callback';
+    const registerRes = mockRes();
+    await broker.handle(
+      mockReq('POST', '/oauth/register', `redirect_uris=${encodeURIComponent(redirectUri)}`),
+      registerRes,
+      '/oauth/register',
+    );
+    const { client_id: clientId } = registerRes.body as { client_id: string };
+    const challenge = createHash('sha256').update('verifier').digest('base64url');
+
+    const authorizeRes = mockRes();
+    await broker.handle(
+      mockReq(
+        'GET',
+        authorizeUrl(clientId, redirectUri, challenge).replace(
+          encodeURIComponent(RESOURCE),
+          encodeURIComponent(invokeResource),
+        ),
+      ),
+      authorizeRes,
+      '/oauth/authorize',
+    );
+    expect(authorizeRes.statusCode).toBe(302);
   });
 
   it('returns an MCP-issued resource-bound token and never exposes Lightdash tokens', async () => {

--- a/packages/mcp/src/auth/oauth-broker/routes.test.ts
+++ b/packages/mcp/src/auth/oauth-broker/routes.test.ts
@@ -408,6 +408,27 @@ describe('oauth broker DCR + authorize binding', () => {
     expect(String(authorizeRes.headers.Location)).toContain('/api/v1/oauth/authorize');
   });
 
+  it('accepts a public profile resource when PUBLIC_URL includes a default port', async () => {
+    const broker = createOAuthBroker(baseConfig({ publicUrl: 'https://mcp.example.com:443' }));
+    const redirectUri = 'http://127.0.0.1:8787/callback';
+    const registerRes = mockRes();
+    await broker.handle(
+      mockReq('POST', '/oauth/register', `redirect_uris=${encodeURIComponent(redirectUri)}`),
+      registerRes,
+      '/oauth/register',
+    );
+    const { client_id: clientId } = registerRes.body as { client_id: string };
+    const challenge = createHash('sha256').update('verifier').digest('base64url');
+
+    const authorizeRes = mockRes();
+    await broker.handle(
+      mockReq('GET', authorizeUrl(clientId, redirectUri, challenge)),
+      authorizeRes,
+      '/oauth/authorize',
+    );
+    expect(authorizeRes.statusCode).toBe(302);
+  });
+
   it('accepts an extra invoke-origin resource that includes a default port', async () => {
     const invokeResource = 'http://mcp.ilb.internal:80/semantic-layer/v1/mcp';
     const broker = createOAuthBroker(
@@ -436,6 +457,92 @@ describe('oauth broker DCR + authorize binding', () => {
       '/oauth/authorize',
     );
     expect(authorizeRes.statusCode).toBe(302);
+  });
+
+  it('mints a portless audience when authorize and token use a default-port invoke resource', async () => {
+    const portedResource = 'http://mcp.ilb.internal:80/semantic-layer/v1/mcp';
+    const canonicalResource = 'http://mcp.ilb.internal/semantic-layer/v1/mcp';
+    const config = baseConfig({ invokeOrigins: [new URL('http://mcp.ilb.internal')] });
+    const broker = createOAuthBroker(config);
+    const redirectUri = 'http://127.0.0.1:8787/callback';
+    const verifier = 'test-verifier-value-1234567890';
+    const challenge = createHash('sha256').update(verifier).digest('base64url');
+
+    const registerRes = mockRes();
+    await broker.handle(
+      mockReq('POST', '/oauth/register', `redirect_uris=${encodeURIComponent(redirectUri)}`),
+      registerRes,
+      '/oauth/register',
+    );
+    const { client_id: clientId } = registerRes.body as { client_id: string };
+
+    const authorizeRes = mockRes();
+    await broker.handle(
+      mockReq(
+        'GET',
+        authorizeUrl(clientId, redirectUri, challenge).replace(
+          encodeURIComponent(RESOURCE),
+          encodeURIComponent(portedResource),
+        ),
+      ),
+      authorizeRes,
+      '/oauth/authorize',
+    );
+    expect(authorizeRes.statusCode).toBe(302);
+    const ldAuthorize = new URL(String(authorizeRes.headers.Location));
+    const brokerState = ldAuthorize.searchParams.get('state');
+    expect(brokerState).toBeTruthy();
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          access_token: 'ld-access',
+          refresh_token: 'ld-refresh',
+          token_type: 'Bearer',
+          expires_in: 3600,
+          scope: 'mcp:read',
+        }),
+      }),
+    );
+
+    const callbackRes = mockRes();
+    await broker.handle(
+      mockReq('GET', `/oauth/callback?code=ld-code&state=${encodeURIComponent(brokerState!)}`),
+      callbackRes,
+      '/oauth/callback',
+    );
+    expect(callbackRes.statusCode).toBe(302);
+    const callbackLocation = new URL(String(callbackRes.headers.Location));
+    const code = callbackLocation.searchParams.get('code');
+    expect(code).toBeTruthy();
+
+    const tokenRes = mockRes();
+    await broker.handle(
+      mockReq(
+        'POST',
+        '/oauth/token',
+        new URLSearchParams({
+          grant_type: 'authorization_code',
+          code: code!,
+          redirect_uri: redirectUri,
+          client_id: clientId,
+          code_verifier: verifier,
+          resource: portedResource,
+        }).toString(),
+      ),
+      tokenRes,
+      '/oauth/token',
+    );
+
+    expect(tokenRes.statusCode).toBe(200);
+    const body = tokenRes.body as { access_token: string };
+    expect(String(body.access_token)).toMatch(/^ldmcp1\./);
+    expect(verifyMcpAccessToken(config, body.access_token, portedResource)).toBeUndefined();
+    expect(verifyMcpAccessToken(config, body.access_token, canonicalResource)).toMatchObject({
+      resource: canonicalResource,
+    });
   });
 
   it('returns an MCP-issued resource-bound token and never exposes Lightdash tokens', async () => {

--- a/packages/mcp/src/auth/oauth-broker/routes.ts
+++ b/packages/mcp/src/auth/oauth-broker/routes.ts
@@ -12,6 +12,7 @@ import { parseJsonBody, readBody } from '../../transports/http-body.js';
 import { sendJson } from '../../transports/http-response.js';
 
 import { buildBrokerAuthorizationServerMetadata } from './as-metadata.js';
+import { allowedResourceOrigins, resourceOriginForRequest } from './invoke-origins.js';
 import {
   buildLightdashAuthorizeUrl,
   exchangeLightdashAuthorizationCode,
@@ -121,10 +122,36 @@ function isAllowedClientRedirectUri(redirectUri: string): boolean {
   }
 }
 
+function canonicalProfileResource(resource: string): string | undefined {
+  try {
+    const url = new URL(resource);
+    if (
+      (url.protocol !== 'http:' && url.protocol !== 'https:') ||
+      url.username !== '' ||
+      url.password !== '' ||
+      url.search !== '' ||
+      url.hash !== ''
+    ) {
+      return undefined;
+    }
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return undefined;
+  }
+}
+
 function isAllowedMcpResource(config: McpHttpConfig, resource: string): boolean {
-  const publicUrl = requirePublicUrl(config, 'OAuth resource validation');
-  return listEnabledProfilePaths(config.enabledProfiles).some(
-    (profilePath) => resource === `${publicUrl}${profilePath}`,
+  const canonical = canonicalProfileResource(resource);
+  if (canonical === undefined) {
+    return false;
+  }
+  const profilePaths = listEnabledProfilePaths(config.enabledProfiles);
+  const origins = allowedResourceOrigins(
+    requirePublicUrl(config, 'OAuth resource validation'),
+    config.invokeOrigins,
+  );
+  return origins.some((origin) =>
+    profilePaths.some((profilePath) => canonical === `${origin}${profilePath}`),
   );
 }
 
@@ -581,8 +608,19 @@ async function handleRegister(
   });
 }
 
-function handleAsMetadata(res: ServerResponse, config: McpHttpConfig): void {
-  sendJson(res, 200, buildBrokerAuthorizationServerMetadata(config));
+function handleAsMetadata(req: IncomingMessage, res: ServerResponse, config: McpHttpConfig): void {
+  sendJson(
+    res,
+    200,
+    buildBrokerAuthorizationServerMetadata(
+      config,
+      resourceOriginForRequest(
+        req,
+        config.invokeOrigins,
+        requirePublicUrl(config, 'OAuth resource origin'),
+      ),
+    ),
+  );
 }
 
 const BROKER_PATHS: ReadonlySet<string> = new Set([
@@ -619,7 +657,7 @@ export function createOAuthBroker(
       }
 
       if (path === OAUTH_AUTHORIZATION_SERVER_METADATA_PATH && req.method === 'GET') {
-        handleAsMetadata(res, config);
+        handleAsMetadata(req, res, config);
         return true;
       }
 

--- a/packages/mcp/src/auth/oauth-broker/routes.ts
+++ b/packages/mcp/src/auth/oauth-broker/routes.ts
@@ -140,19 +140,20 @@ function canonicalProfileResource(resource: string): string | undefined {
   }
 }
 
-function isAllowedMcpResource(config: McpHttpConfig, resource: string): boolean {
+function allowedMcpResource(config: McpHttpConfig, resource: string): string | undefined {
   const canonical = canonicalProfileResource(resource);
   if (canonical === undefined) {
-    return false;
+    return undefined;
   }
   const profilePaths = listEnabledProfilePaths(config.enabledProfiles);
   const origins = allowedResourceOrigins(
     requirePublicUrl(config, 'OAuth resource validation'),
     config.invokeOrigins,
   );
-  return origins.some((origin) =>
+  const allowed = origins.some((origin) =>
     profilePaths.some((profilePath) => canonical === `${origin}${profilePath}`),
   );
+  return allowed ? canonical : undefined;
 }
 
 type AuthorizeParseFail = { ok: false; status: number; body: Record<string, string> };
@@ -271,7 +272,8 @@ async function parseAuthorizeRequest(
     };
   }
   const resource = resources[0]!;
-  if (!isAllowedMcpResource(config, resource)) {
+  const allowedResource = allowedMcpResource(config, resource);
+  if (allowedResource === undefined) {
     return {
       ok: false,
       status: 400,
@@ -289,7 +291,7 @@ async function parseAuthorizeRequest(
       redirectUri: registered.redirectUri,
       clientState: query.get('state') ?? undefined,
       codeChallenge,
-      resource,
+      resource: allowedResource,
       scope: query.get('scope') ?? undefined,
     },
   };
@@ -498,7 +500,7 @@ async function validateTokenGrant(
     return restoreInvalidGrant(store, candidate, 'client_id mismatch');
   }
 
-  if (candidate.resource !== request.resource) {
+  if (candidate.resource !== canonicalProfileResource(request.resource)) {
     return restoreInvalidGrant(store, candidate, 'resource mismatch');
   }
 

--- a/packages/mcp/src/auth/resource-server/lightdash-oauth-middleware.test.ts
+++ b/packages/mcp/src/auth/resource-server/lightdash-oauth-middleware.test.ts
@@ -22,9 +22,13 @@ const baseConfig = makeTestMcpHttpConfig({
   requiredScopes: [],
 });
 
-function createRequest(authorization?: string): IncomingMessage {
+function createRequest(authorization?: string, headers?: Record<string, string>): IncomingMessage {
   return {
-    headers: authorization ? { authorization } : {},
+    headers: {
+      ...(authorization ? { authorization } : {}),
+      ...headers,
+    },
+    socket: {},
   } as IncomingMessage;
 }
 
@@ -259,6 +263,58 @@ describe('authenticateLightdashOAuth', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.accessToken).toBe('ld-upstream-token');
+  });
+
+  it('challenges and verifies against an extra invoke-origin resource when Host matches', async () => {
+    const invokeOrigin = new URL('http://mcp.ilb.internal');
+    const invokeConfig = makeTestMcpHttpConfig({
+      oauthClientId: 'ld-client',
+      oauthClientSecret: new SecretString('test-lightdash-confidential-client-secret'),
+      requiredScopes: [],
+      invokeOrigins: [invokeOrigin],
+    });
+    const invokeHeaders = {
+      host: 'mcp.ilb.internal',
+      'x-forwarded-proto': 'http',
+    };
+    const invokeResource = `http://mcp.ilb.internal${SEMANTIC_LAYER_PROFILE_PATH}`;
+
+    const challenge = await authenticateLightdashOAuth(
+      createRequest(undefined, invokeHeaders),
+      invokeConfig,
+      SEMANTIC_LAYER_PROFILE_PATH,
+    );
+    expect(challenge.ok).toBe(false);
+    if (challenge.ok) return;
+    expect(challenge.wwwAuthenticate).toContain(
+      'http://mcp.ilb.internal/.well-known/oauth-protected-resource/semantic-layer/v1/mcp',
+    );
+
+    vi.mocked(validateLightdashAccessToken).mockResolvedValue({
+      userUuid: 'user-1',
+      email: 'user@example.com',
+    });
+
+    const invokeToken = mintMcpAccessToken(invokeConfig, {
+      lightdashAccessToken: 'ld-upstream-token',
+      clientId: 'mcp-client-1',
+      resource: invokeResource,
+      expiresAtMs: Date.now() + 60_000,
+    }).accessToken;
+
+    const ok = await authenticateLightdashOAuth(
+      createRequest(`Bearer ${invokeToken}`, invokeHeaders),
+      invokeConfig,
+      SEMANTIC_LAYER_PROFILE_PATH,
+    );
+    expect(ok.ok).toBe(true);
+
+    const publicHostRejectsInvokeToken = await authenticateLightdashOAuth(
+      createRequest(`Bearer ${invokeToken}`, { host: 'mcp.example.com' }),
+      invokeConfig,
+      SEMANTIC_LAYER_PROFILE_PATH,
+    );
+    expect(publicHostRejectsInvokeToken.ok).toBe(false);
   });
 });
 

--- a/packages/mcp/src/auth/resource-server/lightdash-oauth-middleware.ts
+++ b/packages/mcp/src/auth/resource-server/lightdash-oauth-middleware.ts
@@ -1,5 +1,7 @@
+import { requirePublicUrl } from '../../config/public-url.js';
 import { sendJson } from '../../transports/http-response.js';
 import { extractBearerToken } from '../bearer.js';
+import { resourceOriginForRequest } from '../oauth-broker/invoke-origins.js';
 import { verifyMcpAccessToken } from '../oauth-broker/mcp-access-token.js';
 
 import { validateLightdashAccessToken } from './lightdash-token-validation.js';
@@ -38,8 +40,9 @@ export type OAuthAuthResult = OAuthAuthFailure | OAuthAuthSuccess;
 export function buildBearerRequiredFailure(
   config: McpHttpConfig,
   mcpPath: string,
+  resourceOrigin: string,
 ): OAuthAuthFailure {
-  const resourceMetadataUrl = getProtectedResourceMetadataPathUrl(config, mcpPath);
+  const resourceMetadataUrl = getProtectedResourceMetadataPathUrl(config, mcpPath, resourceOrigin);
   const scope = config.requiredScopes.join(' ');
   return {
     ok: false,
@@ -81,13 +84,22 @@ export async function authenticateLightdashOAuth(
   config: McpHttpConfig,
   mcpPath: string,
 ): Promise<OAuthAuthResult> {
-  const resourceMetadataUrl = getProtectedResourceMetadataPathUrl(config, mcpPath);
-  const expectedResource = buildOAuthProtectedResourceMetadata(config, mcpPath).resource;
+  const resourceOrigin = resourceOriginForRequest(
+    req,
+    config.invokeOrigins,
+    requirePublicUrl(config, 'OAuth resource origin'),
+  );
+  const resourceMetadataUrl = getProtectedResourceMetadataPathUrl(config, mcpPath, resourceOrigin);
+  const expectedResource = buildOAuthProtectedResourceMetadata(
+    config,
+    mcpPath,
+    resourceOrigin,
+  ).resource;
   const scope = config.requiredScopes.join(' ');
   const token = extractBearerToken(req);
 
   if (!token) {
-    return buildBearerRequiredFailure(config, mcpPath);
+    return buildBearerRequiredFailure(config, mcpPath, resourceOrigin);
   }
 
   // The MCP resource server accepts only tokens minted by its co-located authorization

--- a/packages/mcp/src/auth/resource-server/oauth-protected-resource.ts
+++ b/packages/mcp/src/auth/resource-server/oauth-protected-resource.ts
@@ -25,17 +25,16 @@ export interface OAuthProtectedResourceMetadata {
 export function buildOAuthProtectedResourceMetadata(
   config: McpHttpConfig,
   mcpPath: string,
+  resourceOrigin: string,
 ): OAuthProtectedResourceMetadata {
-  const publicUrl = requirePublicUrl(config, OAUTH_PROTECTED_RESOURCE_CONTEXT);
   const path = normalizeMcpPath(mcpPath);
 
-  // Broker mode: authorization_servers is the MCP host (PUBLIC_URL). Clients discover
-  // AS metadata at {PUBLIC_URL}/.well-known/oauth-authorization-server and never need
-  // the Lightdash client secret. The broker issues its own access token bound to this
-  // exact resource; the downstream Lightdash credential remains a separate OAuth leg.
+  // Broker mode: authorization_servers is the MCP host clients should use for AS
+  // discovery. On PUBLIC_URL that is the public origin. On an extra invoke origin
+  // it is that origin so private-network clients do not fetch public well-known.
   return {
-    resource: `${publicUrl}${path}`,
-    authorization_servers: [publicUrl],
+    resource: `${resourceOrigin}${path}`,
+    authorization_servers: [resourceOrigin],
     bearer_methods_supported: ['header'],
     scopes_supported: config.scopesSupported,
   };
@@ -49,10 +48,10 @@ export function getProtectedResourceMetadataUrl(config: McpHttpConfig): string {
 export function getProtectedResourceMetadataPathUrl(
   config: McpHttpConfig,
   mcpPath: string,
+  resourceOrigin: string,
 ): string {
-  const publicUrl = requirePublicUrl(config, OAUTH_PROTECTED_RESOURCE_CONTEXT);
   const resourcePath = normalizeMcpPath(mcpPath).replace(/^\//, '');
-  return `${publicUrl}${OAUTH_PROTECTED_RESOURCE_ROOT}/${resourcePath}`;
+  return `${resourceOrigin}${OAUTH_PROTECTED_RESOURCE_ROOT}/${resourcePath}`;
 }
 
 /**

--- a/packages/mcp/src/auth/resource-server/www-authenticate.test.ts
+++ b/packages/mcp/src/auth/resource-server/www-authenticate.test.ts
@@ -28,7 +28,11 @@ describe('getAuthorizationServerMetadataUrl', () => {
 
 describe('buildOAuthProtectedResourceMetadata', () => {
   it('includes resource and MCP host as authorization_servers', () => {
-    const metadata = buildOAuthProtectedResourceMetadata(baseConfig, SEMANTIC_LAYER_PROFILE_PATH);
+    const metadata = buildOAuthProtectedResourceMetadata(
+      baseConfig,
+      SEMANTIC_LAYER_PROFILE_PATH,
+      'https://mcp.example.com',
+    );
     expect(metadata).toEqual({
       resource: `https://mcp.example.com${SEMANTIC_LAYER_PROFILE_PATH}`,
       authorization_servers: ['https://mcp.example.com'],
@@ -44,13 +48,18 @@ describe('buildOAuthProtectedResourceMetadata', () => {
     const metadata = buildOAuthProtectedResourceMetadata(
       baseConfig,
       ORGANIZATION_AUDIT_PROFILE_PATH,
+      'https://mcp.example.com',
     );
     expect(metadata.resource).toBe(`https://mcp.example.com${ORGANIZATION_AUDIT_PROFILE_PATH}`);
     expect(metadata.authorization_servers).toEqual(['https://mcp.example.com']);
   });
 
   it('builds profile-specific resource metadata for content-reader', () => {
-    const metadata = buildOAuthProtectedResourceMetadata(baseConfig, CONTENT_READER_PROFILE_PATH);
+    const metadata = buildOAuthProtectedResourceMetadata(
+      baseConfig,
+      CONTENT_READER_PROFILE_PATH,
+      'https://mcp.example.com',
+    );
     expect(metadata.resource).toBe(`https://mcp.example.com${CONTENT_READER_PROFILE_PATH}`);
     expect(metadata.authorization_servers).toEqual(['https://mcp.example.com']);
   });

--- a/packages/mcp/src/config/env.ts
+++ b/packages/mcp/src/config/env.ts
@@ -8,6 +8,11 @@ export const ENV_LIGHTDASH_TOOLS_MCP_HTTP_PORT = 'LIGHTDASH_TOOLS_MCP_HTTP_PORT'
 /** Platform listen port (Cloud Run / many PaaS). Used only when dedicated MCP port env is unset. */
 export const ENV_PLATFORM_PORT = 'PORT';
 export const ENV_LIGHTDASH_TOOLS_MCP_PUBLIC_URL = 'LIGHTDASH_TOOLS_MCP_PUBLIC_URL';
+/**
+ * Optional comma-separated extra invoke origins (private load balancer, internal DNS).
+ * On a matching Host, PRM and token/DCR advertise that origin; issuer/authorize stay on PUBLIC_URL.
+ */
+export const ENV_LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS = 'LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS';
 /** Rejected at config load — MCP path is profile-owned (see profiles/). */
 export const ENV_LIGHTDASH_TOOLS_MCP_PATH = 'LIGHTDASH_TOOLS_MCP_PATH';
 /** Optional HTTP mount allowlist (comma-separated ProfileIds). Unset/empty → all. Stdio ignores. */

--- a/packages/mcp/src/config/load-mcp-config.test.ts
+++ b/packages/mcp/src/config/load-mcp-config.test.ts
@@ -12,6 +12,7 @@ import {
   ENV_LIGHTDASH_TOOLS_MCP_AUTH_MODE,
   ENV_LIGHTDASH_TOOLS_MCP_EXPERIMENTAL_IDENTITY_OAUTH,
   ENV_LIGHTDASH_TOOLS_MCP_INSECURE_DEV,
+  ENV_LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS,
   ENV_LIGHTDASH_TOOLS_MCP_PATH,
   ENV_LIGHTDASH_TOOLS_MCP_PROFILES,
   ENV_LIGHTDASH_TOOLS_MCP_PUBLIC_URL,
@@ -269,6 +270,44 @@ describe('loadMcpHttpConfig', () => {
 
     const config = loadMcpHttpConfig();
     expect(config.publicUrl).toBe('http://127.0.0.1:3100');
+  });
+
+  it('parses extra invoke origins in OAuth mode including non-loopback http', () => {
+    setOAuthCreds();
+    process.env[ENV_LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS] =
+      'http://mcp.ilb.internal, https://mcp.example.com';
+
+    const config = loadMcpHttpConfig();
+    expect(config.invokeOrigins.map((origin) => origin.origin)).toEqual([
+      'http://mcp.ilb.internal',
+    ]);
+  });
+
+  it('rejects invalid invoke origins in OAuth mode', () => {
+    setOAuthCreds();
+    process.env[ENV_LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS] = 'not-a-url';
+
+    expect(() => loadMcpHttpConfig()).toThrow(ENV_LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS);
+  });
+
+  it('ignores invoke origins outside OAuth mode', () => {
+    process.env.LIGHTDASH_URL = 'https://app.lightdash.cloud';
+    process.env.NODE_ENV = 'development';
+    process.env[ENV_LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS] = 'not-a-url';
+
+    const config = loadMcpHttpConfig();
+    expect(config.authMode).toBe('none');
+    expect(config.invokeOrigins).toEqual([]);
+  });
+
+  it('warns for non-loopback http invoke origins', () => {
+    setOAuthCreds();
+    process.env[ENV_LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS] = 'http://mcp.ilb.internal';
+    const config = loadMcpHttpConfig();
+    emitMcpHttpSecurityWarnings(config);
+    expect(vi.mocked(console.warn).mock.calls.flat().join('\n')).toMatch(
+      /non-loopback http origins/,
+    );
   });
 
   it('rejects VALIDATE_TOKEN=false in production', () => {

--- a/packages/mcp/src/config/load-mcp-config.ts
+++ b/packages/mcp/src/config/load-mcp-config.ts
@@ -9,6 +9,7 @@ import {
   MCP_AUTH_MODE_NONE,
   MCP_AUTH_MODE_SHARED_KEY,
 } from '../auth/auth-mode.js';
+import { parseInvokeOrigins } from '../auth/oauth-broker/invoke-origins.js';
 import { getDefaultProfile, listProfilePaths } from '../profiles/index.js';
 
 import {
@@ -20,6 +21,7 @@ import {
   ENV_LIGHTDASH_TOOLS_MCP_ALLOWED_ORIGINS,
   ENV_LIGHTDASH_TOOLS_MCP_HTTP_HOST,
   ENV_LIGHTDASH_TOOLS_MCP_HTTP_PORT,
+  ENV_LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS,
   ENV_PLATFORM_PORT,
   ENV_LIGHTDASH_TOOLS_MCP_MAX_BODY_BYTES,
   ENV_LIGHTDASH_TOOLS_MCP_PATH,
@@ -184,6 +186,8 @@ export interface McpHttpConfig {
   host: string;
   port: number;
   publicUrl?: string;
+  /** Extra invoke origins. Parsed only in OAuth mode. */
+  invokeOrigins: URL[];
   mcpPath: string;
   /** HTTP mount allowlist. Unrestricted when LIGHTDASH_TOOLS_MCP_PROFILES is unset. */
   enabledProfiles: EnabledProfilesPolicy;
@@ -274,6 +278,25 @@ function emitLightdashOAuthSecurityWarnings(config: McpHttpConfig): void {
   }
 
   emitNgrokFreeInterstitialWarning(config.publicUrl);
+  emitInvokeOriginWarnings(config);
+}
+
+function emitInvokeOriginWarnings(config: McpHttpConfig): void {
+  const cleartext = config.invokeOrigins.filter(
+    (origin) => origin.protocol === 'http:' && !isLocalHttpOrigin(origin.origin),
+  );
+  if (cleartext.length === 0) {
+    return;
+  }
+
+  const listed = cleartext.map((origin) => origin.origin).join(', ');
+  console.warn(
+    `Warning: ${ENV_LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS} includes non-loopback http origins (${listed}). ` +
+      'On those Hosts, token/DCR and PRM advertise the invoke origin while issuer/authorize stay on ' +
+      `${ENV_LIGHTDASH_TOOLS_MCP_PUBLIC_URL}. This is an intentional RFC 8414 issuer split; ` +
+      '@modelcontextprotocol/client v2 will reject HTTP invoke origins. Point that SDK at public HTTPS. ' +
+      'Do not serve extra origins as the public VIP Host.',
+  );
 }
 
 /** Free ngrok serves ERR_NGROK_6024 for browser-UA GETs; Cursor's post-callback rediscovery uses Mozilla UA. */
@@ -412,6 +435,10 @@ export function loadMcpHttpConfig(
   const mcpPath = resolveRootMcpPath(enabledProfiles);
   const publicUrl = publicUrlRaw ? normalizePublicUrl(publicUrlRaw, listProfilePaths()) : undefined;
   assertPublicUrlSecurity(authMode, publicUrl);
+  const invokeOrigins =
+    authMode === MCP_AUTH_MODE_LIGHTDASH_OAUTH
+      ? parseInvokeOrigins(readEnv(ENV_LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS, env), publicUrl)
+      : [];
 
   const validateToken = parseBooleanEnv(
     ENV_LIGHTDASH_TOOLS_MCP_VALIDATE_TOKEN,
@@ -440,6 +467,7 @@ export function loadMcpHttpConfig(
       ENV_PLATFORM_PORT,
     ),
     publicUrl,
+    invokeOrigins,
     mcpPath,
     enabledProfiles,
     promptContextPolicy,

--- a/packages/mcp/src/config/test-mcp-http-config.ts
+++ b/packages/mcp/src/config/test-mcp-http-config.ts
@@ -10,6 +10,7 @@ export function makeTestMcpHttpConfig(overrides?: Partial<McpHttpConfig>): McpHt
     host: '127.0.0.1',
     port: 3100,
     publicUrl: 'https://mcp.example.com',
+    invokeOrigins: [],
     mcpPath: resolveRootMcpPath(enabledProfiles),
     enabledProfiles,
     promptContextPolicy: 'compact',

--- a/packages/mcp/src/http.integration.helpers.ts
+++ b/packages/mcp/src/http.integration.helpers.ts
@@ -3,12 +3,14 @@ import {
   request as httpRequest,
   type IncomingHttpHeaders,
   type Server,
+  type ServerResponse,
 } from 'node:http';
 
 import { SecretString } from '@lightdash-tools/client';
 
 import { mintMcpAccessToken } from './auth/oauth-broker/mcp-access-token.js';
 import { makeTestMcpHttpConfig } from './config/test-mcp-http-config.js';
+
 import type { McpHttpConfig } from './config/load-mcp-config.js';
 import type { AddressInfo } from 'node:net';
 
@@ -60,14 +62,35 @@ export function listen(server: Server, port: number, host: string): Promise<void
   });
 }
 
+type MockUser = { userUuid: string; email: string; organizationUuid?: string };
+
+function writeJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' }).end(JSON.stringify(body));
+}
+
+function writeUnauthorized(res: ServerResponse): void {
+  writeJson(res, 401, {
+    status: 'error',
+    error: { statusCode: 401, name: 'Unauthorized', message: 'Invalid token' },
+  });
+}
+
+function bearerFromAuth(auth: string): string {
+  return auth.startsWith('Bearer ') ? auth.slice('Bearer '.length).trim() : '';
+}
+
+function userForAuth(auth: string, users: ReadonlyMap<string, MockUser>): MockUser | undefined {
+  return users.get(bearerFromAuth(auth));
+}
+
 export async function startMockLightdashServer(): Promise<MockLightdashServer> {
   const authorizationHeaders: string[] = [];
-  const users: Record<string, { userUuid: string; email: string; organizationUuid?: string }> = {
-    [TOKEN_A]: USER_A,
-    [TOKEN_B]: USER_B,
-    [TOKEN_READ_ONLY]: USER_A,
-    [OPAQUE_TOKEN_A]: USER_A,
-  };
+  const users = new Map<string, MockUser>([
+    [TOKEN_A, USER_A],
+    [TOKEN_B, USER_B],
+    [TOKEN_READ_ONLY, USER_A],
+    [OPAQUE_TOKEN_A, USER_A],
+  ]);
 
   let issuerBaseUrl = '';
 
@@ -77,62 +100,36 @@ export async function startMockLightdashServer(): Promise<MockLightdashServer> {
     authorizationHeaders.push(auth);
 
     if (req.method === 'GET' && req.url === '/.well-known/oauth-authorization-server') {
-      res.writeHead(200, { 'Content-Type': 'application/json' }).end(
-        JSON.stringify({
-          issuer: issuerBaseUrl,
-          authorization_endpoint: `${issuerBaseUrl}/api/v1/oauth/authorize`,
-          token_endpoint: `${issuerBaseUrl}/api/v1/oauth/token`,
-          revocation_endpoint: `${issuerBaseUrl}/api/v1/oauth/revoke`,
-          registration_endpoint: `${issuerBaseUrl}/api/v1/oauth/register`,
-          userinfo_endpoint: `${issuerBaseUrl}/api/v1/oauth/userinfo`,
-        }),
-      );
+      writeJson(res, 200, {
+        issuer: issuerBaseUrl,
+        authorization_endpoint: `${issuerBaseUrl}/api/v1/oauth/authorize`,
+        token_endpoint: `${issuerBaseUrl}/api/v1/oauth/token`,
+        revocation_endpoint: `${issuerBaseUrl}/api/v1/oauth/revoke`,
+        registration_endpoint: `${issuerBaseUrl}/api/v1/oauth/register`,
+        userinfo_endpoint: `${issuerBaseUrl}/api/v1/oauth/userinfo`,
+      });
       return;
     }
 
     if (req.method === 'GET' && req.url === '/api/v1/user') {
-      const token = auth.startsWith('Bearer ') ? auth.slice('Bearer '.length).trim() : '';
-      const user = users[token];
-      if (!user) {
-        res.writeHead(401, { 'Content-Type': 'application/json' }).end(
-          JSON.stringify({
-            status: 'error',
-            error: { statusCode: 401, name: 'Unauthorized', message: 'Invalid token' },
-          }),
-        );
+      const user = userForAuth(auth, users);
+      if (user === undefined) {
+        writeUnauthorized(res);
         return;
       }
-
-      res
-        .writeHead(200, { 'Content-Type': 'application/json' })
-        .end(JSON.stringify({ status: 'ok', results: user }));
+      writeJson(res, 200, { status: 'ok', results: user });
       return;
     }
 
     if (req.method === 'GET' && req.url === '/api/v1/org/projects') {
-      const token = auth.startsWith('Bearer ') ? auth.slice('Bearer '.length).trim() : '';
-      if (!users[token]) {
-        res.writeHead(401, { 'Content-Type': 'application/json' }).end(
-          JSON.stringify({
-            status: 'error',
-            error: { statusCode: 401, name: 'Unauthorized', message: 'Invalid token' },
-          }),
-        );
+      if (userForAuth(auth, users) === undefined) {
+        writeUnauthorized(res);
         return;
       }
-
-      res.writeHead(200, { 'Content-Type': 'application/json' }).end(
-        JSON.stringify({
-          status: 'ok',
-          results: [
-            {
-              projectUuid: 'project-a-uuid',
-              name: 'Project A',
-              type: 'DEFAULT',
-            },
-          ],
-        }),
-      );
+      writeJson(res, 200, {
+        status: 'ok',
+        results: [{ projectUuid: 'project-a-uuid', name: 'Project A', type: 'DEFAULT' }],
+      });
       return;
     }
 

--- a/packages/mcp/src/http.integration.helpers.ts
+++ b/packages/mcp/src/http.integration.helpers.ts
@@ -1,0 +1,258 @@
+import {
+  createServer,
+  request as httpRequest,
+  type IncomingHttpHeaders,
+  type Server,
+} from 'node:http';
+
+import { SecretString } from '@lightdash-tools/client';
+
+import { mintMcpAccessToken } from './auth/oauth-broker/mcp-access-token.js';
+import { makeTestMcpHttpConfig } from './config/test-mcp-http-config.js';
+import type { McpHttpConfig } from './config/load-mcp-config.js';
+import type { AddressInfo } from 'node:net';
+
+// These constants model downstream Lightdash credentials only. MCP clients never send
+// them directly after ADR-0026; tests wrap them in broker-issued MCP access tokens.
+export const TOKEN_A = scopedAccessToken('mcp:read mcp:write', 'token-a');
+export const TOKEN_B = scopedAccessToken('mcp:read mcp:write', 'token-b');
+export const TOKEN_READ_ONLY = scopedAccessToken('mcp:read', 'token-read-only');
+export const OPAQUE_TOKEN_A = 'opaque-token-user-a';
+
+const USER_A = { userUuid: 'user-a-uuid', email: 'a@example.com', organizationUuid: 'org-a-uuid' };
+const USER_B = { userUuid: 'user-b-uuid', email: 'b@example.com', organizationUuid: 'org-b-uuid' };
+
+function scopedAccessToken(scope: string, subject: string): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ scope, sub: subject })).toString('base64url');
+  return `${header}.${payload}.signature`;
+}
+
+export const INITIALIZE_BODY = {
+  jsonrpc: '2.0',
+  method: 'initialize',
+  params: {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'integration-test', version: '1.0.0' },
+  },
+  id: 1,
+};
+
+export interface MockLightdashServer {
+  baseUrl: string;
+  authorizationHeaders: string[];
+  close: () => Promise<void>;
+}
+
+export interface McpHttpServer {
+  baseUrl: string;
+  close: () => Promise<void>;
+}
+
+export function listen(server: Server, port: number, host: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, host, () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+}
+
+export async function startMockLightdashServer(): Promise<MockLightdashServer> {
+  const authorizationHeaders: string[] = [];
+  const users: Record<string, { userUuid: string; email: string; organizationUuid?: string }> = {
+    [TOKEN_A]: USER_A,
+    [TOKEN_B]: USER_B,
+    [TOKEN_READ_ONLY]: USER_A,
+    [OPAQUE_TOKEN_A]: USER_A,
+  };
+
+  let issuerBaseUrl = '';
+
+  const server = createServer((req, res) => {
+    const authHeader = req.headers.authorization;
+    const auth = typeof authHeader === 'string' ? authHeader : (authHeader?.[0] ?? '');
+    authorizationHeaders.push(auth);
+
+    if (req.method === 'GET' && req.url === '/.well-known/oauth-authorization-server') {
+      res.writeHead(200, { 'Content-Type': 'application/json' }).end(
+        JSON.stringify({
+          issuer: issuerBaseUrl,
+          authorization_endpoint: `${issuerBaseUrl}/api/v1/oauth/authorize`,
+          token_endpoint: `${issuerBaseUrl}/api/v1/oauth/token`,
+          revocation_endpoint: `${issuerBaseUrl}/api/v1/oauth/revoke`,
+          registration_endpoint: `${issuerBaseUrl}/api/v1/oauth/register`,
+          userinfo_endpoint: `${issuerBaseUrl}/api/v1/oauth/userinfo`,
+        }),
+      );
+      return;
+    }
+
+    if (req.method === 'GET' && req.url === '/api/v1/user') {
+      const token = auth.startsWith('Bearer ') ? auth.slice('Bearer '.length).trim() : '';
+      const user = users[token];
+      if (!user) {
+        res.writeHead(401, { 'Content-Type': 'application/json' }).end(
+          JSON.stringify({
+            status: 'error',
+            error: { statusCode: 401, name: 'Unauthorized', message: 'Invalid token' },
+          }),
+        );
+        return;
+      }
+
+      res
+        .writeHead(200, { 'Content-Type': 'application/json' })
+        .end(JSON.stringify({ status: 'ok', results: user }));
+      return;
+    }
+
+    if (req.method === 'GET' && req.url === '/api/v1/org/projects') {
+      const token = auth.startsWith('Bearer ') ? auth.slice('Bearer '.length).trim() : '';
+      if (!users[token]) {
+        res.writeHead(401, { 'Content-Type': 'application/json' }).end(
+          JSON.stringify({
+            status: 'error',
+            error: { statusCode: 401, name: 'Unauthorized', message: 'Invalid token' },
+          }),
+        );
+        return;
+      }
+
+      res.writeHead(200, { 'Content-Type': 'application/json' }).end(
+        JSON.stringify({
+          status: 'ok',
+          results: [
+            {
+              projectUuid: 'project-a-uuid',
+              name: 'Project A',
+              type: 'DEFAULT',
+            },
+          ],
+        }),
+      );
+      return;
+    }
+
+    res.writeHead(404).end();
+  });
+
+  await listen(server, 0, '127.0.0.1');
+  const address = server.address() as AddressInfo;
+  issuerBaseUrl = `http://127.0.0.1:${address.port}`;
+
+  return {
+    baseUrl: issuerBaseUrl,
+    authorizationHeaders,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      }),
+  };
+}
+
+export function baseOAuthConfig(
+  lightdashUrl: string,
+  overrides?: Partial<McpHttpConfig>,
+): McpHttpConfig {
+  return makeTestMcpHttpConfig({
+    lightdashUrl,
+    port: 0,
+    publicUrl: 'http://127.0.0.1:0',
+    oauthClientId: 'test-client-id',
+    oauthClientSecret: new SecretString('test-client-secret'),
+    maxBodyBytes: 1024 * 1024,
+    requiredScopes: [],
+    scopesSupported: [],
+    ...overrides,
+  });
+}
+
+export function brokerAccessToken(
+  mcpBaseUrl: string,
+  lightdashAccessToken: string,
+  options: { path?: string; scope?: string } = {},
+): string {
+  const path = options.path ?? '/semantic-layer/v1/mcp';
+  return mintMcpAccessToken(baseOAuthConfig('https://lightdash.invalid'), {
+    lightdashAccessToken,
+    clientId: 'integration-test-client',
+    resource: `${mcpBaseUrl}${path}`,
+    scope: options.scope,
+    expiresAtMs: Date.now() + 60_000,
+  }).accessToken;
+}
+
+export function nodeRequest(options: {
+  baseUrl: string;
+  path: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}): Promise<{
+  status: number;
+  headers: IncomingHttpHeaders;
+  json: unknown;
+}> {
+  const url = new URL(options.path, options.baseUrl);
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: `${url.pathname}${url.search}`,
+        method: options.method ?? 'GET',
+        headers: options.headers,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => {
+          const text = Buffer.concat(chunks).toString('utf8');
+          let json: unknown = text;
+          try {
+            json = JSON.parse(text);
+          } catch {
+            // keep text
+          }
+          resolve({
+            status: res.statusCode ?? 0,
+            headers: res.headers,
+            json,
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    if (options.body !== undefined) {
+      req.write(options.body);
+    }
+    req.end();
+  });
+}
+
+export async function postMcp(
+  baseUrl: string,
+  body: unknown,
+  options?: { token?: string; path?: string },
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream',
+  };
+  if (options?.token) {
+    headers.Authorization = `Bearer ${options.token}`;
+  }
+
+  const path = options?.path ?? '/semantic-layer/v1/mcp';
+  return fetch(`${baseUrl}${path}`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+}

--- a/packages/mcp/src/http.integration.test.ts
+++ b/packages/mcp/src/http.integration.test.ts
@@ -1,211 +1,28 @@
-import { createServer, type Server } from 'node:http';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
 
 import { SecretString } from '@lightdash-tools/client';
 import { CLIENT_CAPABILITIES_META_KEY } from '@modelcontextprotocol/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { mintMcpAccessToken } from './auth/oauth-broker/mcp-access-token.js';
 import { getAuthorizationServerMetadataUrl } from './auth/resource-server/oauth-protected-resource.js';
 import { parseEnabledProfiles } from './config/enabled-profiles.js';
 import { makeTestMcpHttpConfig } from './config/test-mcp-http-config.js';
+import {
+  INITIALIZE_BODY,
+  OPAQUE_TOKEN_A,
+  TOKEN_A,
+  TOKEN_B,
+  TOKEN_READ_ONLY,
+  baseOAuthConfig,
+  brokerAccessToken,
+  listen,
+  postMcp,
+  startMockLightdashServer,
+  type McpHttpServer,
+  type MockLightdashServer,
+} from './http.integration.helpers.js';
 import { createStreamableHttpServer } from './transports/streamable-http.js';
-
-import type { McpHttpConfig } from './config/load-mcp-config.js';
-import type { AddressInfo } from 'node:net';
-
-// These constants model downstream Lightdash credentials only. MCP clients never send
-// them directly after ADR-0026; tests wrap them in broker-issued MCP access tokens.
-const TOKEN_A = scopedAccessToken('mcp:read mcp:write', 'token-a');
-const TOKEN_B = scopedAccessToken('mcp:read mcp:write', 'token-b');
-const TOKEN_READ_ONLY = scopedAccessToken('mcp:read', 'token-read-only');
-const OPAQUE_TOKEN_A = 'opaque-token-user-a';
-
-const USER_A = { userUuid: 'user-a-uuid', email: 'a@example.com', organizationUuid: 'org-a-uuid' };
-const USER_B = { userUuid: 'user-b-uuid', email: 'b@example.com', organizationUuid: 'org-b-uuid' };
-
-function scopedAccessToken(scope: string, subject: string): string {
-  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
-  const payload = Buffer.from(JSON.stringify({ scope, sub: subject })).toString('base64url');
-  return `${header}.${payload}.signature`;
-}
-
-const INITIALIZE_BODY = {
-  jsonrpc: '2.0',
-  method: 'initialize',
-  params: {
-    protocolVersion: '2024-11-05',
-    capabilities: {},
-    clientInfo: { name: 'integration-test', version: '1.0.0' },
-  },
-  id: 1,
-};
-
-interface MockLightdashServer {
-  baseUrl: string;
-  authorizationHeaders: string[];
-  close: () => Promise<void>;
-}
-
-interface McpHttpServer {
-  baseUrl: string;
-  close: () => Promise<void>;
-}
-
-function listen(server: Server, port: number, host: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(port, host, () => {
-      server.removeListener('error', reject);
-      resolve();
-    });
-  });
-}
-
-async function startMockLightdashServer(): Promise<MockLightdashServer> {
-  const authorizationHeaders: string[] = [];
-  const users: Record<string, { userUuid: string; email: string; organizationUuid?: string }> = {
-    [TOKEN_A]: USER_A,
-    [TOKEN_B]: USER_B,
-    [TOKEN_READ_ONLY]: USER_A,
-    [OPAQUE_TOKEN_A]: USER_A,
-  };
-
-  let issuerBaseUrl = '';
-
-  const server = createServer((req, res) => {
-    const authHeader = req.headers.authorization;
-    const auth = typeof authHeader === 'string' ? authHeader : (authHeader?.[0] ?? '');
-    authorizationHeaders.push(auth);
-
-    if (req.method === 'GET' && req.url === '/.well-known/oauth-authorization-server') {
-      res.writeHead(200, { 'Content-Type': 'application/json' }).end(
-        JSON.stringify({
-          issuer: issuerBaseUrl,
-          authorization_endpoint: `${issuerBaseUrl}/api/v1/oauth/authorize`,
-          token_endpoint: `${issuerBaseUrl}/api/v1/oauth/token`,
-          revocation_endpoint: `${issuerBaseUrl}/api/v1/oauth/revoke`,
-          registration_endpoint: `${issuerBaseUrl}/api/v1/oauth/register`,
-          userinfo_endpoint: `${issuerBaseUrl}/api/v1/oauth/userinfo`,
-        }),
-      );
-      return;
-    }
-
-    if (req.method === 'GET' && req.url === '/api/v1/user') {
-      const token = auth.startsWith('Bearer ') ? auth.slice('Bearer '.length).trim() : '';
-      const user = users[token];
-      if (!user) {
-        res.writeHead(401, { 'Content-Type': 'application/json' }).end(
-          JSON.stringify({
-            status: 'error',
-            error: { statusCode: 401, name: 'Unauthorized', message: 'Invalid token' },
-          }),
-        );
-        return;
-      }
-
-      res
-        .writeHead(200, { 'Content-Type': 'application/json' })
-        .end(JSON.stringify({ status: 'ok', results: user }));
-      return;
-    }
-
-    if (req.method === 'GET' && req.url === '/api/v1/org/projects') {
-      const token = auth.startsWith('Bearer ') ? auth.slice('Bearer '.length).trim() : '';
-      if (!users[token]) {
-        res.writeHead(401, { 'Content-Type': 'application/json' }).end(
-          JSON.stringify({
-            status: 'error',
-            error: { statusCode: 401, name: 'Unauthorized', message: 'Invalid token' },
-          }),
-        );
-        return;
-      }
-
-      res.writeHead(200, { 'Content-Type': 'application/json' }).end(
-        JSON.stringify({
-          status: 'ok',
-          results: [
-            {
-              projectUuid: 'project-a-uuid',
-              name: 'Project A',
-              type: 'DEFAULT',
-            },
-          ],
-        }),
-      );
-      return;
-    }
-
-    res.writeHead(404).end();
-  });
-
-  await listen(server, 0, '127.0.0.1');
-  const address = server.address() as AddressInfo;
-  issuerBaseUrl = `http://127.0.0.1:${address.port}`;
-
-  return {
-    baseUrl: issuerBaseUrl,
-    authorizationHeaders,
-    close: () =>
-      new Promise<void>((resolve, reject) => {
-        server.close((err) => {
-          if (err) reject(err);
-          else resolve();
-        });
-      }),
-  };
-}
-
-function baseOAuthConfig(lightdashUrl: string, overrides?: Partial<McpHttpConfig>): McpHttpConfig {
-  return makeTestMcpHttpConfig({
-    lightdashUrl,
-    port: 0,
-    publicUrl: 'http://127.0.0.1:0',
-    oauthClientId: 'test-client-id',
-    oauthClientSecret: new SecretString('test-client-secret'),
-    maxBodyBytes: 1024 * 1024,
-    requiredScopes: [],
-    scopesSupported: [],
-    ...overrides,
-  });
-}
-
-function brokerAccessToken(
-  mcpBaseUrl: string,
-  lightdashAccessToken: string,
-  options: { path?: string; scope?: string } = {},
-): string {
-  const path = options.path ?? '/semantic-layer/v1/mcp';
-  return mintMcpAccessToken(baseOAuthConfig('https://lightdash.invalid'), {
-    lightdashAccessToken,
-    clientId: 'integration-test-client',
-    resource: `${mcpBaseUrl}${path}`,
-    scope: options.scope,
-    expiresAtMs: Date.now() + 60_000,
-  }).accessToken;
-}
-
-async function postMcp(
-  baseUrl: string,
-  body: unknown,
-  options?: { token?: string; path?: string },
-): Promise<Response> {
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-    Accept: 'application/json, text/event-stream',
-  };
-  if (options?.token) {
-    headers.Authorization = `Bearer ${options.token}`;
-  }
-
-  const path = options?.path ?? '/semantic-layer/v1/mcp';
-  return fetch(`${baseUrl}${path}`, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(body),
-  });
-}
 
 function parseSseOrJsonToolText(raw: string): string {
   if (raw.includes('data:')) {

--- a/packages/mcp/src/http.integration.test.ts
+++ b/packages/mcp/src/http.integration.test.ts
@@ -1,5 +1,4 @@
 import { createServer } from 'node:http';
-import type { AddressInfo } from 'node:net';
 
 import { SecretString } from '@lightdash-tools/client';
 import { CLIENT_CAPABILITIES_META_KEY } from '@modelcontextprotocol/server';
@@ -19,10 +18,11 @@ import {
   listen,
   postMcp,
   startMockLightdashServer,
-  type McpHttpServer,
-  type MockLightdashServer,
 } from './http.integration.helpers.js';
 import { createStreamableHttpServer } from './transports/streamable-http.js';
+
+import type { McpHttpServer, MockLightdashServer } from './http.integration.helpers.js';
+import type { AddressInfo } from 'node:net';
 
 function parseSseOrJsonToolText(raw: string): string {
   if (raw.includes('data:')) {

--- a/packages/mcp/src/http.invoke-origin.integration.test.ts
+++ b/packages/mcp/src/http.invoke-origin.integration.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  INITIALIZE_BODY,
+  TOKEN_A,
+  baseOAuthConfig,
+  brokerAccessToken,
+  nodeRequest,
+  postMcp,
+  startMockLightdashServer,
+  type McpHttpServer,
+  type MockLightdashServer,
+} from './http.integration.helpers.js';
+import { createStreamableHttpServer } from './transports/streamable-http.js';
+
+describe('MCP HTTP extra invoke-origin OAuth', () => {
+  const invokeHost = 'mcp.ilb.internal';
+  const invokeOrigin = `http://${invokeHost}`;
+  let mockLightdash: MockLightdashServer;
+  let mcpServer: McpHttpServer;
+
+  beforeEach(async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    mockLightdash = await startMockLightdashServer();
+    mcpServer = await createStreamableHttpServer({
+      ...baseOAuthConfig(mockLightdash.baseUrl, {
+        invokeOrigins: [new URL(invokeOrigin)],
+      }),
+    });
+  });
+
+  afterEach(async () => {
+    await mcpServer.close();
+    await mockLightdash.close();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps public PRM and AS metadata on the listen Host', async () => {
+    const prm = await fetch(`${mcpServer.baseUrl}/.well-known/oauth-protected-resource`);
+    expect(prm.status).toBe(200);
+    const prmBody = (await prm.json()) as { resource: string; authorization_servers: string[] };
+    expect(prmBody.authorization_servers).toEqual([mcpServer.baseUrl]);
+    expect(prmBody.resource).toBe(`${mcpServer.baseUrl}/semantic-layer/v1/mcp`);
+
+    const asRes = await fetch(`${mcpServer.baseUrl}/.well-known/oauth-authorization-server`);
+    const asBody = (await asRes.json()) as {
+      issuer: string;
+      token_endpoint: string;
+    };
+    expect(asBody.issuer).toBe(mcpServer.baseUrl);
+    expect(asBody.token_endpoint).toBe(`${mcpServer.baseUrl}/oauth/token`);
+  });
+
+  it('advertises invoke-origin PRM and token/DCR when Host matches', async () => {
+    const headers = { host: invokeHost, 'x-forwarded-proto': 'http' };
+    const prm = await nodeRequest({
+      baseUrl: mcpServer.baseUrl,
+      path: '/.well-known/oauth-protected-resource',
+      headers,
+    });
+    expect(prm.status).toBe(200);
+    expect(prm.json).toEqual({
+      resource: `${invokeOrigin}/semantic-layer/v1/mcp`,
+      authorization_servers: [invokeOrigin],
+      bearer_methods_supported: ['header'],
+      scopes_supported: [],
+    });
+
+    const asRes = await nodeRequest({
+      baseUrl: mcpServer.baseUrl,
+      path: '/.well-known/oauth-authorization-server',
+      headers,
+    });
+    expect(asRes.status).toBe(200);
+    const asBody = asRes.json as {
+      issuer: string;
+      authorization_endpoint: string;
+      token_endpoint: string;
+      registration_endpoint: string;
+    };
+    expect(asBody.issuer).toBe(mcpServer.baseUrl);
+    expect(asBody.authorization_endpoint).toBe(`${mcpServer.baseUrl}/oauth/authorize`);
+    expect(asBody.token_endpoint).toBe(`${invokeOrigin}/oauth/token`);
+    expect(asBody.registration_endpoint).toBe(`${invokeOrigin}/oauth/register`);
+  });
+
+  it('does not inherit invoke metadata for the same hostname on another port', async () => {
+    const prm = await nodeRequest({
+      baseUrl: mcpServer.baseUrl,
+      path: '/.well-known/oauth-protected-resource',
+      headers: { host: `${invokeHost}:9999`, 'x-forwarded-proto': 'http' },
+    });
+    expect(prm.status).toBe(200);
+    const body = prm.json as { authorization_servers: string[] };
+    expect(body.authorization_servers).toEqual([mcpServer.baseUrl]);
+  });
+
+  it('verifies an invoke-origin token only when Host matches that origin', async () => {
+    const invokeToken = brokerAccessToken(invokeOrigin, TOKEN_A);
+    const invokeHeaders = {
+      host: invokeHost,
+      'x-forwarded-proto': 'http',
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream',
+      authorization: `Bearer ${invokeToken}`,
+    };
+
+    const ok = await nodeRequest({
+      baseUrl: mcpServer.baseUrl,
+      path: '/semantic-layer/v1/mcp',
+      method: 'POST',
+      headers: invokeHeaders,
+      body: JSON.stringify(INITIALIZE_BODY),
+    });
+    expect(ok.status).toBe(200);
+
+    const mismatch = await postMcp(mcpServer.baseUrl, INITIALIZE_BODY, { token: invokeToken });
+    expect(mismatch.status).toBe(401);
+  });
+
+  it('rejects a public-audience token when Host is the extra invoke origin', async () => {
+    const publicToken = brokerAccessToken(mcpServer.baseUrl, TOKEN_A);
+    const res = await nodeRequest({
+      baseUrl: mcpServer.baseUrl,
+      path: '/semantic-layer/v1/mcp',
+      method: 'POST',
+      headers: {
+        host: invokeHost,
+        'x-forwarded-proto': 'http',
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        authorization: `Bearer ${publicToken}`,
+      },
+      body: JSON.stringify(INITIALIZE_BODY),
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/mcp/src/http.invoke-origin.integration.test.ts
+++ b/packages/mcp/src/http.invoke-origin.integration.test.ts
@@ -8,10 +8,10 @@ import {
   nodeRequest,
   postMcp,
   startMockLightdashServer,
-  type McpHttpServer,
-  type MockLightdashServer,
 } from './http.integration.helpers.js';
 import { createStreamableHttpServer } from './transports/streamable-http.js';
+
+import type { McpHttpServer, MockLightdashServer } from './http.integration.helpers.js';
 
 describe('MCP HTTP extra invoke-origin OAuth', () => {
   const invokeHost = 'mcp.ilb.internal';

--- a/packages/mcp/src/transports/streamable-http.test.ts
+++ b/packages/mcp/src/transports/streamable-http.test.ts
@@ -89,7 +89,11 @@ describe('streamable HTTP security policy', () => {
 
 describe('streamable HTTP OAuth metadata', () => {
   it('builds protected resource metadata with MCP host as authorization_servers', () => {
-    const metadata = buildOAuthProtectedResourceMetadata(oauthConfig, SEMANTIC_LAYER_PROFILE_PATH);
+    const metadata = buildOAuthProtectedResourceMetadata(
+      oauthConfig,
+      SEMANTIC_LAYER_PROFILE_PATH,
+      'https://mcp.example.com',
+    );
     expect(metadata.authorization_servers).toEqual(['https://mcp.example.com']);
     expect(metadata.resource).toBe(`https://mcp.example.com${SEMANTIC_LAYER_PROFILE_PATH}`);
     expect(getAuthorizationServerMetadataUrl(metadata.authorization_servers[0])).toBe(
@@ -97,16 +101,31 @@ describe('streamable HTTP OAuth metadata', () => {
     );
   });
 
+  it('builds protected resource metadata for an extra invoke origin', () => {
+    const metadata = buildOAuthProtectedResourceMetadata(
+      oauthConfig,
+      SEMANTIC_LAYER_PROFILE_PATH,
+      'http://mcp.ilb.internal',
+    );
+    expect(metadata.resource).toBe('http://mcp.ilb.internal/semantic-layer/v1/mcp');
+    expect(metadata.authorization_servers).toEqual(['http://mcp.ilb.internal']);
+  });
+
   it('builds organization-audit protected resource metadata', () => {
     const metadata = buildOAuthProtectedResourceMetadata(
       oauthConfig,
       ORGANIZATION_AUDIT_PROFILE_PATH,
+      'https://mcp.example.com',
     );
     expect(metadata.resource).toBe(`https://mcp.example.com${ORGANIZATION_AUDIT_PROFILE_PATH}`);
   });
 
   it('builds content-reader protected resource metadata', () => {
-    const metadata = buildOAuthProtectedResourceMetadata(oauthConfig, CONTENT_READER_PROFILE_PATH);
+    const metadata = buildOAuthProtectedResourceMetadata(
+      oauthConfig,
+      CONTENT_READER_PROFILE_PATH,
+      'https://mcp.example.com',
+    );
     expect(metadata.resource).toBe(`https://mcp.example.com${CONTENT_READER_PROFILE_PATH}`);
   });
 

--- a/packages/mcp/src/transports/streamable-http.ts
+++ b/packages/mcp/src/transports/streamable-http.ts
@@ -10,6 +10,7 @@ import {
   MCP_AUTH_MODE_NONE,
   MCP_AUTH_MODE_SHARED_KEY,
 } from '../auth/auth-mode.js';
+import { resourceOriginForRequest } from '../auth/oauth-broker/invoke-origins.js';
 import {
   createOAuthBroker,
   isOAuthBrokerPath,
@@ -41,6 +42,7 @@ import {
   emitMcpHttpSecurityWarnings,
   type McpHttpConfig,
 } from '../config/load-mcp-config.js';
+import { requirePublicUrl } from '../config/public-url.js';
 import { getClient, getAuditLogPath, warnIgnoredCliGuardrailEnvVars } from '../config/runtime.js';
 import { validateAvailableProjectsConfig } from '../governance/available-projects.js';
 import {
@@ -435,7 +437,19 @@ async function handlePublicHttpPaths(
       : undefined;
   if (prmMcpPath !== undefined) {
     applyOptionalCorsHeaders(req, res, config, true);
-    sendJson(res, 200, buildOAuthProtectedResourceMetadata(config, prmMcpPath));
+    sendJson(
+      res,
+      200,
+      buildOAuthProtectedResourceMetadata(
+        config,
+        prmMcpPath,
+        resourceOriginForRequest(
+          req,
+          config.invokeOrigins,
+          requirePublicUrl(config, 'OAuth resource origin'),
+        ),
+      ),
+    );
     return true;
   }
 


### PR DESCRIPTION
## Summary
- Add optional `LIGHTDASH_TOOLS_MCP_INVOKE_ORIGINS` so VPC clients (internal LB / private DNS) get host-aware PRM and token/DCR URLs without pointing `PUBLIC_URL` at HTTP.
- On a matching `Host` (scheme + host + port), token/DCR and PRM use the extra origin; issuer, authorize, and callback stay on `PUBLIC_URL`. Bearer verify binds to the request Host resource.
- Document the split in ADR-0027 and the OAuth operator/threat-model notes. `@modelcontextprotocol/client` v2 remains public HTTPS only.

## Test plan
- [ ] `pnpm exec vitest run packages/mcp/src/http.invoke-origin.integration.test.ts packages/mcp/src/auth/oauth-broker/invoke-origins.test.ts packages/mcp/src/auth/oauth-broker/routes.test.ts`
- [ ] Confirm Host `mcp.ilb.internal` + `X-Forwarded-Proto: http` advertises token/DCR on that origin and issuer on `PUBLIC_URL`
- [ ] Confirm Host `mcp.ilb.internal:9999` does not inherit invoke-origin PRM
- [ ] Confirm a public-audience token is 401 on the extra-origin Host (and the inverse)
- [ ] Wait for CI to pass before marking the PR ready


Made with [Cursor](https://cursor.com)