### PR TITLE
chore: bump package versions to 0.16.1

### DIFF
--- a/.changes/0.16.1.
+++ b/.changes/0.16.1.
@@ -1,0 +1,7 @@
+## [0.16.1] - 2026-08-20
+### Features
+* MCP progressive-disclosure prompt context (compact default; compatible/embedded via LIGHTDASH_TOOLS_MCP_PROMPT_CONTEXT)
+### Documentation
+* Document MCP HTTP health probes (/health/live, /health/ready) in the package README and Cloud Run operator guide.
+### Chores
+* Sync OpenAPI types to Lightdash 1.109.1

--- a/.changes/unreleased/chore-20260810-140854.yaml
+++ b/.changes/unreleased/chore-20260810-140854.yaml
@@ -1,3 +1,0 @@
-kind: chore
-body: Sync OpenAPI types to Lightdash 1.109.1
-time: 2026-08-10T14:08:54.443516192Z

--- a/.changes/unreleased/docs-20260810-111919.yaml
+++ b/.changes/unreleased/docs-20260810-111919.yaml
@@ -1,3 +1,0 @@
-kind: docs
-body: Document MCP HTTP health probes (/health/live, /health/ready) in the package README and Cloud Run operator guide.
-time: 2026-08-10T11:19:19.772527+09:00

--- a/.changes/unreleased/feat-prompt-context.yaml
+++ b/.changes/unreleased/feat-prompt-context.yaml
@@ -1,3 +1,0 @@
-kind: feat
-body: MCP progressive-disclosure prompt context (compact default; compatible/embedded via LIGHTDASH_TOOLS_MCP_PROMPT_CONTEXT)
-time: 2026-08-11T08:40:00Z

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.16.1] - 2026-08-20
+
+### Features
+
+- MCP progressive-disclosure prompt context (compact default; compatible/embedded via LIGHTDASH_TOOLS_MCP_PROMPT_CONTEXT)
+
+### Documentation
+
+- Document MCP HTTP health probes (/health/live, /health/ready) in the package README and Cloud Run operator guide.
+
+### Chores
+
+- Sync OpenAPI types to Lightdash 1.109.1
+
 ## [0.14.0] - 2026-08-10
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools",
-  "version": "0.14.0",
+  "version": "0.16.1",
   "private": true,
   "description": "",
   "keywords": [],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/cli",
-  "version": "0.14.0",
+  "version": "0.16.1",
   "description": "CLI for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,7 +35,7 @@ const program = new Command();
 program
   .name('lightdash-ai')
   .description('CLI for Lightdash AI')
-  .version('0.14.0')
+  .version('0.16.1')
   .option(
     '--safety-mode <mode>',
     'Safety mode (read-only, write-idempotent, write-destructive)',

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/client",
-  "version": "0.14.0",
+  "version": "0.16.1",
   "description": "Client library for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/common",
-  "version": "0.14.0",
+  "version": "0.16.1",
   "description": "Shared utilities and types for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/mcp",
-  "version": "0.14.0",
+  "version": "0.16.1",
   "description": "MCP server for Lightdash semantic-layer, organization-audit, content-reader, content-developer, content-governance, and ai-agent-ops profiles.",
   "keywords": [],
   "repository": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bumps all monorepo package versions from `0.14.0` to `0.16.1` and batches unreleased changelog fragments into the new release.

## Changes

- Root and workspace `package.json` versions updated to `0.16.1`
- CLI entrypoint version string synced in `packages/cli/src/index.ts`
- MCP continues to read version from `package.json` via `PACKAGE_VERSION`
- Unreleased changie fragments batched and merged into `CHANGELOG.md`

## Changelog (0.16.1)

### Features
- MCP progressive-disclosure prompt context (compact default; compatible/embedded via `LIGHTDASH_TOOLS_MCP_PROMPT_CONTEXT`)

### Documentation
- Document MCP HTTP health probes (`/health/live`, `/health/ready`) in the package README and Cloud Run operator guide

### Chores
- Sync OpenAPI types to Lightdash 1.109.1
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26f698c1-9309-499a-b6d1-296ede4edb81?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26f698c1-9309-499a-b6d1-296ede4edb81&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

