### PR TITLE
chore: bump package versions to 0.19.0

### DIFF
--- a/.changes/0.19.0.
+++ b/.changes/0.19.0.
@@ -1,0 +1,8 @@
+## [0.19.0] - 2026-08-21
+### Features
+* Add ai-agent-chat MCP profile for using existing Lightdash AI Agents (ADR-0029).
+* ai-agent-chat: add route_agent (AI Router) and URL/UUID grounding playbooks (ADR-0031)
+### Bug Fixes
+* Require prompt on ai-agent-chat create_agent_thread; empty create fails upstream (ADR-0030).
+### Documentation
+* Clarify ai-agent-chat prompts/playbooks as new-conversation-by-default with own-thread continue only (no cross-user takeover).

--- a/.changes/unreleased/docs-ai-agent-chat-new-by-default-prompts.yaml
+++ b/.changes/unreleased/docs-ai-agent-chat-new-by-default-prompts.yaml
@@ -1,3 +1,0 @@
-kind: docs
-body: Clarify ai-agent-chat prompts/playbooks as new-conversation-by-default with own-thread continue only (no cross-user takeover).
-time: 2026-08-21T02:48:00Z

--- a/.changes/unreleased/feat-20260821-123621.yaml
+++ b/.changes/unreleased/feat-20260821-123621.yaml
@@ -1,3 +1,0 @@
-kind: feat
-body: 'ai-agent-chat: add route_agent (AI Router) and URL/UUID grounding playbooks (ADR-0031)'
-time: 2026-08-21T12:36:21.639189+09:00

--- a/.changes/unreleased/feat-ai-agent-chat-mcp-profile.yaml
+++ b/.changes/unreleased/feat-ai-agent-chat-mcp-profile.yaml
@@ -1,3 +1,0 @@
-kind: feat
-body: Add ai-agent-chat MCP profile for using existing Lightdash AI Agents (ADR-0029).
-time: 2026-08-20T12:00:00Z

--- a/.changes/unreleased/fix-20260821-115746.yaml
+++ b/.changes/unreleased/fix-20260821-115746.yaml
@@ -1,3 +1,0 @@
-kind: fix
-body: Require prompt on ai-agent-chat create_agent_thread; empty create fails upstream (ADR-0030).
-time: 2026-08-21T11:57:46.597111+09:00

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.19.0] - 2026-08-21
+
+### Features
+
+- Add ai-agent-chat MCP profile for using existing Lightdash AI Agents (ADR-0029).
+- ai-agent-chat: add route_agent (AI Router) and URL/UUID grounding playbooks (ADR-0031)
+
+### Bug Fixes
+
+- Require prompt on ai-agent-chat create_agent_thread; empty create fails upstream (ADR-0030).
+
+### Documentation
+
+- Clarify ai-agent-chat prompts/playbooks as new-conversation-by-default with own-thread continue only (no cross-user takeover).
+
 ## [0.18.0] - 2026-08-20
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "private": true,
   "description": "",
   "keywords": [],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/cli",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "CLI for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,7 +35,7 @@ const program = new Command();
 program
   .name('lightdash-ai')
   .description('CLI for Lightdash AI')
-  .version('0.18.0')
+  .version('0.19.0')
   .option(
     '--safety-mode <mode>',
     'Safety mode (read-only, write-idempotent, write-destructive)',

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/client",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Client library for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/common",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Shared utilities and types for Lightdash AI.",
   "keywords": [],
   "repository": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightdash-tools/mcp",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "MCP server for Lightdash semantic-layer, organization-audit, content-reader, content-developer, content-governance, ai-agent-ops, ai-agent-chat, and data-analyst profiles.",
   "keywords": [],
   "repository": {


### PR DESCRIPTION
## Summary
- Bump monorepo package versions from 0.18.0 to 0.19.0 (root, cli, client, common, mcp)
- Batch unreleased changie fragments into 0.19.0 and merge into CHANGELOG.md
- Sync CLI `.version()` string to match the release

## Test plan
- [ ] Confirm all `package.json` files and CLI `.version()` report `0.19.0`
- [ ] Confirm CHANGELOG.md has a `## [0.19.0]` section and unreleased fragments are cleared
- [ ] CI passes on this draft PR


Made with [Cursor](https://cursor.com)